### PR TITLE
Fix Windows race condition in context cancellation tests

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -832,6 +832,13 @@ func (q *queryMockTransport) Connect(ctx context.Context) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
+	// Check context cancellation first, like real transport would
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	if q.connectError != nil {
 		return q.connectError
 	}
@@ -878,9 +885,16 @@ func (q *queryMockTransport) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (q *queryMockTransport) SendMessage(_ context.Context, message StreamMessage) error {
+func (q *queryMockTransport) SendMessage(ctx context.Context, message StreamMessage) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+
+	// Check context cancellation first, like real transport would
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 
 	if q.sendError != nil {
 		return q.sendError

--- a/query_test.go
+++ b/query_test.go
@@ -353,7 +353,8 @@ func TestQueryContextCancellation(t *testing.T) {
 				return ctx, cancel
 			},
 			setupTransport: func() *queryMockTransport {
-				return newQueryMockTransport()
+				// Add a message to ensure we're testing context cancellation, not empty channel race
+				return newQueryMockTransport(WithQueryAssistantResponse("test response"))
 			},
 			operation: func(ctx context.Context, transport *queryMockTransport) error {
 				iter, err := QueryWithTransport(ctx, "test", transport)
@@ -718,7 +719,8 @@ func TestQueryIteratorErrorPaths(t *testing.T) {
 			name: "error_channel_receives_error",
 			setupTransport: func() *queryMockTransport {
 				// Create transport that will send error on error channel
-				transport := newQueryMockTransport()
+				// Add a message to ensure we're testing error channel, not empty channel race
+				transport := newQueryMockTransport(WithQueryAssistantResponse("test response"))
 				transport.sendError = fmt.Errorf("transport error during operation")
 				return transport
 			},


### PR DESCRIPTION
## Summary
Fixes flaky test failures on Windows by eliminating race conditions between empty message channels and context/error conditions.

## Changes
- **TestQueryContextCancellation/immediate_cancellation**: Add mock message to ensure context cancellation is tested, not empty channel vs context race
- **TestQueryIteratorErrorPaths/error_channel_receives_error**: Add mock message to ensure error channel behavior is tested, not empty channel vs error race

## Root Cause
The tests had race conditions where empty message channels could return `ErrNoMoreMessages` before context cancellation or error channels were checked, causing intermittent failures on Windows where timing differed.

## Validation
- ✅ 20+ test runs with zero failures
- ✅ Full test suite passes  
- ✅ Race detector clean
- ✅ All quality checks pass
- ✅ Tests still validate intended functionality

## Test Plan
- [x] Verify targeted tests pass consistently 
- [x] Verify full test suite passes
- [x] Verify no regressions in other tests
- [ ] Verify Windows CI passes