### PR TITLE
fix: remove invalid --cwd flag from CLI command construction

### DIFF
--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -198,9 +198,7 @@ func addSessionFlags(cmd []string, options *shared.Options) []string {
 }
 
 func addFileSystemFlags(cmd []string, options *shared.Options) []string {
-	if options.Cwd != nil {
-		cmd = append(cmd, "--cwd", *options.Cwd)
-	}
+	// Note: Working directory is set via exec.Cmd.Dir in transport layer, not as a CLI flag
 	for _, dir := range options.AddDirs {
 		cmd = append(cmd, "--add-dir", dir)
 	}

--- a/internal/cli/discovery_test.go
+++ b/internal/cli/discovery_test.go
@@ -78,6 +78,26 @@ func TestCommandBuilding(t *testing.T) {
 	}
 }
 
+// TestCwdNotAddedToCommand tests that WithCwd() doesn't add --cwd flag
+func TestCwdNotAddedToCommand(t *testing.T) {
+	cwd := "/workspace/test"
+	options := &shared.Options{
+		Cwd: &cwd,
+	}
+
+	cmd := BuildCommand("/usr/local/bin/claude", options, false)
+
+	// Verify --cwd flag is NOT in the command
+	assertNotContainsArg(t, cmd, "--cwd")
+
+	// Verify the working directory path is also NOT in the command
+	for _, arg := range cmd {
+		if arg == cwd {
+			t.Errorf("Expected command to not contain working directory path %s as argument, got %v", cwd, cmd)
+		}
+	}
+}
+
 // TestCLIDiscoveryLocations tests CLI discovery path generation
 func TestCLIDiscoveryLocations(t *testing.T) {
 	locations := getCommonCLILocations()


### PR DESCRIPTION
## Problem
The Claude CLI does not support a `--cwd` flag. This was causing CLI parsing failures when `WithCwd()` option was used.

## Solution
- Removes the invalid `--cwd` flag from `addFileSystemFlags` function
- Working directory is already correctly set via `exec.Cmd.Dir` in the transport layer
- Adds tests to verify correct behavior

## Changes
- `internal/cli/discovery.go`: Remove --cwd flag
- `internal/cli/discovery_test.go`: Add test for flag absence
- `internal/subprocess/transport_test.go`: Add test for exec.Cmd.Dir

## Testing
- ✅ Verified --cwd flag is not added to commands
- ✅ Verified exec.Cmd.Dir is set correctly when WithCwd() is used
