### PR TITLE
feat: implement WithMcpServers() for programmatic MCP server configuration

### DIFF
--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -208,8 +208,10 @@ func addFileSystemFlags(cmd []string, options *shared.Options) []string {
 }
 
 func addMCPFlags(cmd []string, _ *shared.Options) []string {
-	// TODO: Implement MCP configuration file generation when len(options.McpServers) > 0
-	// For now, skip MCP servers - this will be added in a subsequent commit
+	// Note: MCP server configuration is handled by the Transport layer.
+	// When options.McpServers is set, Transport generates a temporary config file
+	// and adds it to ExtraArgs as "--mcp-config", which is then added by addExtraFlags().
+	// This function is kept for potential future direct MCP flag support.
 	return cmd
 }
 

--- a/internal/subprocess/transport_test.go
+++ b/internal/subprocess/transport_test.go
@@ -2,6 +2,7 @@ package subprocess
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -957,6 +958,238 @@ func TestSubprocessEnvironmentVariables(t *testing.T) {
 			} else {
 				t.Error("Expected command environment to be set")
 			}
+		})
+	}
+}
+
+// TestTransportWorkingDirectory tests that working directory is set via exec.Cmd.Dir
+func TestTransportWorkingDirectory(t *testing.T) {
+	ctx, cancel := setupTransportTestContext(t, 5*time.Second)
+	defer cancel()
+
+	tests := []struct {
+		name     string
+		setup    func() *Transport
+		validate func(*testing.T, *Transport)
+	}{
+		{
+			name: "working_directory_set_via_cmd_dir",
+			setup: func() *Transport {
+				cwd := t.TempDir()
+				options := &shared.Options{
+					Cwd: &cwd,
+				}
+				return New(newTransportMockCLI(), options, false, "sdk-go")
+			},
+			validate: func(t *testing.T, transport *Transport) {
+				t.Helper()
+				if transport.cmd == nil {
+					t.Fatal("Expected command to be initialized after Connect()")
+				}
+				expectedCwd := *transport.options.Cwd
+				if transport.cmd.Dir != expectedCwd {
+					t.Errorf("Expected cmd.Dir to be %s, got %s", expectedCwd, transport.cmd.Dir)
+				}
+			},
+		},
+		{
+			name: "no_working_directory_when_cwd_nil",
+			setup: func() *Transport {
+				options := &shared.Options{
+					Cwd: nil,
+				}
+				return New(newTransportMockCLI(), options, false, "sdk-go")
+			},
+			validate: func(t *testing.T, transport *Transport) {
+				t.Helper()
+				if transport.cmd == nil {
+					t.Fatal("Expected command to be initialized after Connect()")
+				}
+				if transport.cmd.Dir != "" {
+					t.Errorf("Expected cmd.Dir to be empty when Cwd is nil, got %s", transport.cmd.Dir)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := tt.setup()
+			defer disconnectTransportSafely(t, transport)
+
+			// Connect to initialize the command
+			err := transport.Connect(ctx)
+			assertNoTransportError(t, err)
+
+			// Validate working directory was set correctly via cmd.Dir
+			tt.validate(t, transport)
+		})
+	}
+}
+
+// TestTransportMcpServerConfiguration tests MCP server config file generation
+func TestTransportMcpServerConfiguration(t *testing.T) {
+	ctx, cancel := setupTransportTestContext(t, 5*time.Second)
+	defer cancel()
+
+	tests := []struct {
+		name     string
+		setup    func() *Transport
+		validate func(*testing.T, *Transport)
+	}{
+		{
+			name: "mcp_config_file_generated",
+			setup: func() *Transport {
+				mcpServers := map[string]shared.McpServerConfig{
+					"test-server": &shared.McpStdioServerConfig{
+						Type:    shared.McpServerTypeStdio,
+						Command: "node",
+						Args:    []string{"test-server.js"},
+						Env:     map[string]string{"TEST_VAR": "test_value"},
+					},
+				}
+				options := &shared.Options{
+					McpServers: mcpServers,
+				}
+				return New(newTransportMockCLI(), options, false, "sdk-go")
+			},
+			validate: func(t *testing.T, transport *Transport) {
+				t.Helper()
+				if transport.mcpConfigFile == nil {
+					t.Fatal("Expected MCP config file to be generated")
+				}
+
+				// Read and verify the generated config file
+				configData, err := os.ReadFile(transport.mcpConfigFile.Name())
+				if err != nil {
+					t.Fatalf("Failed to read MCP config file: %v", err)
+				}
+
+				// Verify it's valid JSON
+				var config map[string]interface{}
+				if err := json.Unmarshal(configData, &config); err != nil {
+					t.Fatalf("MCP config is not valid JSON: %v", err)
+				}
+
+				// Verify structure
+				mcpServers, ok := config["mcpServers"].(map[string]interface{})
+				if !ok {
+					t.Fatal("MCP config missing 'mcpServers' key")
+				}
+
+				testServer, ok := mcpServers["test-server"].(map[string]interface{})
+				if !ok {
+					t.Fatal("MCP config missing 'test-server'")
+				}
+
+				if testServer["command"] != "node" {
+					t.Errorf("Expected command 'node', got %v", testServer["command"])
+				}
+			},
+		},
+		{
+			name: "mcp_config_file_cleaned_up",
+			setup: func() *Transport {
+				mcpServers := map[string]shared.McpServerConfig{
+					"cleanup-test": &shared.McpStdioServerConfig{
+						Type:    shared.McpServerTypeStdio,
+						Command: "echo",
+						Args:    []string{"test"},
+					},
+				}
+				options := &shared.Options{
+					McpServers: mcpServers,
+				}
+				return New(newTransportMockCLI(), options, false, "sdk-go")
+			},
+			validate: func(t *testing.T, transport *Transport) {
+				t.Helper()
+				if transport.mcpConfigFile == nil {
+					t.Fatal("Expected MCP config file to be generated")
+				}
+
+				configPath := transport.mcpConfigFile.Name()
+
+				// Verify file exists while transport is connected
+				if _, err := os.Stat(configPath); os.IsNotExist(err) {
+					t.Error("MCP config file should exist while transport is connected")
+				}
+
+				// Close transport and verify cleanup
+				if err := transport.Close(); err != nil {
+					t.Errorf("Failed to close transport: %v", err)
+				}
+
+				// Verify file is deleted after cleanup
+				if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+					t.Error("MCP config file should be deleted after transport Close()")
+				}
+			},
+		},
+		{
+			name: "no_mcp_config_when_servers_empty",
+			setup: func() *Transport {
+				options := &shared.Options{
+					McpServers: nil,
+				}
+				return New(newTransportMockCLI(), options, false, "sdk-go")
+			},
+			validate: func(t *testing.T, transport *Transport) {
+				t.Helper()
+				if transport.mcpConfigFile != nil {
+					t.Error("MCP config file should not be generated when McpServers is empty")
+				}
+			},
+		},
+		{
+			name: "mcp_config_added_to_extra_args",
+			setup: func() *Transport {
+				mcpServers := map[string]shared.McpServerConfig{
+					"args-test": &shared.McpStdioServerConfig{
+						Type:    shared.McpServerTypeStdio,
+						Command: "test",
+					},
+				}
+				options := &shared.Options{
+					McpServers: mcpServers,
+					ExtraArgs:  map[string]*string{"existing": stringPtr("value")},
+				}
+				return New(newTransportMockCLI(), options, false, "sdk-go")
+			},
+			validate: func(t *testing.T, transport *Transport) {
+				t.Helper()
+				// Verify the command includes --mcp-config flag
+				if transport.cmd == nil {
+					t.Fatal("Expected command to be initialized")
+				}
+
+				cmdStr := strings.Join(transport.cmd.Args, " ")
+				if !strings.Contains(cmdStr, "--mcp-config") {
+					t.Errorf("Expected command to contain --mcp-config flag, got: %s", cmdStr)
+				}
+
+				// Verify original ExtraArgs was not mutated
+				if transport.options.ExtraArgs["mcp-config"] != nil {
+					t.Error("Original options.ExtraArgs should not be mutated")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := tt.setup()
+			// Note: cleanup is handled in the validate function for cleanup test
+			if tt.name != "mcp_config_file_cleaned_up" {
+				defer disconnectTransportSafely(t, transport)
+			}
+
+			// Connect to trigger MCP config generation
+			err := transport.Connect(ctx)
+			assertNoTransportError(t, err)
+
+			// Run validation
+			tt.validate(t, transport)
 		})
 	}
 }


### PR DESCRIPTION
Implements SDK_ISSUES.md Issue #2 (MEDIUM severity)

## Problem
`WithMcpServers()` function was a stub that didn't actually configure MCP servers.

## Solution
- Transport generates temporary MCP config JSON file when `McpServers` is set
- Config file path is automatically added to `--mcp-config` CLI flag
- Temporary file is cleaned up when transport is closed
- Merges with Claude's default MCP config (no `--strict` flag)
- Original options object is not mutated (creates safe copy)

## Changes
- `internal/cli/discovery.go`: Update MCP flags documentation
- `internal/subprocess/transport.go`: Add MCP config file generation and cleanup
- `internal/subprocess/transport_test.go`: Comprehensive tests for config generation

## Example Usage
```go
mcpServers := map[string]claudecode.McpServerConfig{
    "my-server": &claudecode.McpStdioServerConfig{
        Type:    claudecode.McpServerTypeStdio,
        Command: "npx",
        Args:    []string{"-y", "my-mcp-server"},
    },
}
client := claudecode.NewClient(claudecode.WithMcpServers(mcpServers))
```

## Testing
- ✅ Config file generation from McpServers map
- ✅ Temp file cleanup on Close()
- ✅ Original options not mutated
