### PR TITLE
fix: increase scanner buffer to 1MB to handle large tool results

### DIFF
--- a/internal/subprocess/transport.go
+++ b/internal/subprocess/transport.go
@@ -323,6 +323,14 @@ func (t *Transport) handleStdout() {
 
 	scanner := bufio.NewScanner(t.stdout)
 
+	// Increase scanner buffer to handle large tool results (files, etc.)
+	// Default bufio.Scanner has MaxScanTokenSize of 64KB which is insufficient
+	// for tool results containing large files. We use 1MB to match parser's
+	// MaxBufferSize and handle files up to ~900KB after JSON encoding overhead.
+	const maxScanTokenSize = 1024 * 1024 // 1MB
+	buf := make([]byte, maxScanTokenSize)
+	scanner.Buffer(buf, maxScanTokenSize)
+
 	for scanner.Scan() {
 		select {
 		case <-t.ctx.Done():


### PR DESCRIPTION
## Problem
Subprocess crashes when tool results contain large files (>64KB after JSON encoding). The default `bufio.Scanner` MaxScanTokenSize of 64KB was insufficient for tool results containing large files, especially markdown files with high JSON encoding overhead from special characters.

The scanner would silently fail when encountering lines exceeding the buffer, causing the stdout handling goroutine to terminate prematurely and resulting in incomplete message streams.

## Root Cause
- Default scanner buffer: 64KB
- Large markdown files after JSON encoding can exceed this limit
- Example: architecture.md (83KB) → ~110KB JSON-encoded → Crash
- Scanner.Scan() returns false silently, no error or panic

## Solution
Increase scanner buffer to 1MB to match parser's MaxBufferSize, allowing files up to ~900KB after JSON encoding overhead. This provides 3.5x safety margin since Read tool has 256KB limit.

## Changes
- `internal/subprocess/transport.go` (lines 360-366): Increase scanner buffer to 1MB

## Testing
- ✅ Tested with architecture.md (83KB, 2606 lines)
- ✅ Tested with 1MB+ files (handled by Read tool 256KB limit)
- ✅ All existing tests pass
