### PR TITLE
feat: add stream validation API to detect incomplete message streams

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1142,6 +1142,10 @@ func (c *clientMockTransport) injectTestMessage(msg Message) {
 	}
 }
 
+func (c *clientMockTransport) GetValidator() *StreamValidator {
+	return &StreamValidator{}
+}
+
 // Streamlined Mock Transport Options - reduced from 11 to 6 essential functions
 type ClientMockTransportOption func(*clientMockTransport)
 

--- a/internal/shared/validator.go
+++ b/internal/shared/validator.go
@@ -1,0 +1,144 @@
+package shared
+
+import (
+	"sync"
+)
+
+// StreamValidator tracks tool requests and results to detect incomplete streams.
+type StreamValidator struct {
+	mu              sync.RWMutex
+	toolsRequested  map[string]bool   // Set of all tool_use IDs requested
+	toolsReceived   map[string]bool   // Set of all tool_result IDs received
+	pendingToolsSet map[string]bool   // Set of tool IDs awaiting results
+	hasResultMessage bool              // Whether we've seen a result message
+	streamEnded     bool               // Whether stream has ended
+	issues          []StreamIssue      // Validation issues found
+}
+
+// StreamIssue represents a validation issue found in the stream.
+type StreamIssue struct {
+	Type        string `json:"type"`        // "missing_tool_result", "extra_tool_result", etc.
+	Description string `json:"description"` // Human-readable description
+	ToolUseID   string `json:"tool_use_id,omitempty"` // Related tool use ID if applicable
+}
+
+// StreamStats provides statistics about the message stream.
+type StreamStats struct {
+	ToolsRequested int      `json:"tools_requested"` // Total tools requested
+	ToolsReceived  int      `json:"tools_received"`  // Total tool results received
+	PendingTools   []string `json:"pending_tools"`   // Tool IDs still awaiting results
+	HasResult      bool     `json:"has_result"`      // Whether result message was seen
+	StreamEnded    bool     `json:"stream_ended"`    // Whether stream has ended
+}
+
+// NewStreamValidator creates a new stream validator.
+func NewStreamValidator() *StreamValidator {
+	return &StreamValidator{
+		toolsRequested:  make(map[string]bool),
+		toolsReceived:   make(map[string]bool),
+		pendingToolsSet: make(map[string]bool),
+		issues:          []StreamIssue{},
+	}
+}
+
+// TrackMessage processes a message and updates validation state.
+func (v *StreamValidator) TrackMessage(msg Message) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	switch m := msg.(type) {
+	case *AssistantMessage:
+		// Track tool use requests
+		for _, block := range m.Content {
+			if toolUse, ok := block.(*ToolUseBlock); ok {
+				v.toolsRequested[toolUse.ToolUseID] = true
+				v.pendingToolsSet[toolUse.ToolUseID] = true
+			}
+		}
+
+	case *UserMessage:
+		// Track tool results
+		if blocks, ok := m.Content.([]ContentBlock); ok {
+			for _, block := range blocks {
+				if toolResult, ok := block.(*ToolResultBlock); ok {
+					v.toolsReceived[toolResult.ToolUseID] = true
+					delete(v.pendingToolsSet, toolResult.ToolUseID)
+
+					// Check for extra tool results (results without requests)
+					if !v.toolsRequested[toolResult.ToolUseID] {
+						v.issues = append(v.issues, StreamIssue{
+							Type:        "extra_tool_result",
+							Description: "Received tool result without corresponding tool request",
+							ToolUseID:   toolResult.ToolUseID,
+						})
+					}
+				}
+			}
+		}
+
+	case *ResultMessage:
+		v.hasResultMessage = true
+	}
+}
+
+// MarkStreamEnd marks the stream as ended and performs final validation.
+func (v *StreamValidator) MarkStreamEnd() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	v.streamEnded = true
+
+	// Check for missing tool results
+	for toolID := range v.pendingToolsSet {
+		v.issues = append(v.issues, StreamIssue{
+			Type:        "missing_tool_result",
+			Description: "Tool was requested but result was never received",
+			ToolUseID:   toolID,
+		})
+	}
+
+	// Check for missing result message
+	if len(v.toolsRequested) > 0 && !v.hasResultMessage {
+		v.issues = append(v.issues, StreamIssue{
+			Type:        "missing_result_message",
+			Description: "Stream ended without result message",
+		})
+	}
+}
+
+// GetIssues returns all validation issues found.
+func (v *StreamValidator) GetIssues() []StreamIssue {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	// Return a copy to prevent external modification
+	issues := make([]StreamIssue, len(v.issues))
+	copy(issues, v.issues)
+	return issues
+}
+
+// GetStats returns current stream statistics.
+func (v *StreamValidator) GetStats() StreamStats {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	pendingTools := make([]string, 0, len(v.pendingToolsSet))
+	for toolID := range v.pendingToolsSet {
+		pendingTools = append(pendingTools, toolID)
+	}
+
+	return StreamStats{
+		ToolsRequested: len(v.toolsRequested),
+		ToolsReceived:  len(v.toolsReceived),
+		PendingTools:   pendingTools,
+		HasResult:      v.hasResultMessage,
+		StreamEnded:    v.streamEnded,
+	}
+}
+
+// HasIssues returns whether any validation issues were found.
+func (v *StreamValidator) HasIssues() bool {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return len(v.issues) > 0
+}

--- a/internal/shared/validator_test.go
+++ b/internal/shared/validator_test.go
@@ -1,0 +1,318 @@
+package shared
+
+import (
+	"sync"
+	"testing"
+)
+
+// Test functions first (primary purpose)
+
+func TestStreamValidator_CompleteStream(t *testing.T) {
+	validator := NewStreamValidator()
+
+	// Simulate complete stream: request → result → final result
+	assistantMsg := &AssistantMessage{
+		Content: []ContentBlock{
+			&ToolUseBlock{
+				ToolUseID: "tool_123",
+				Name:      "read_file",
+			},
+		},
+	}
+
+	userMsg := &UserMessage{
+		Content: []ContentBlock{
+			&ToolResultBlock{
+				ToolUseID: "tool_123",
+				Content:   "file contents",
+			},
+		},
+	}
+
+	resultMsg := &ResultMessage{}
+
+	validator.TrackMessage(assistantMsg)
+	validator.TrackMessage(userMsg)
+	validator.TrackMessage(resultMsg)
+	validator.MarkStreamEnd()
+
+	// Validate no issues
+	issues := validator.GetIssues()
+	if len(issues) != 0 {
+		t.Errorf("Expected no issues, got %d: %+v", len(issues), issues)
+	}
+
+	// Validate stats
+	stats := validator.GetStats()
+	if stats.ToolsRequested != 1 {
+		t.Errorf("Expected 1 tool requested, got %d", stats.ToolsRequested)
+	}
+	if stats.ToolsReceived != 1 {
+		t.Errorf("Expected 1 tool received, got %d", stats.ToolsReceived)
+	}
+	if len(stats.PendingTools) != 0 {
+		t.Errorf("Expected no pending tools, got %d", len(stats.PendingTools))
+	}
+	if !stats.HasResult {
+		t.Error("Expected result message to be tracked")
+	}
+}
+
+func TestStreamValidator_MissingToolResult(t *testing.T) {
+	validator := NewStreamValidator()
+
+	// Simulate stream with missing tool result
+	assistantMsg := &AssistantMessage{
+		Content: []ContentBlock{
+			&ToolUseBlock{
+				ToolUseID: "tool_123",
+				Name:      "read_file",
+			},
+		},
+	}
+
+	validator.TrackMessage(assistantMsg)
+	validator.MarkStreamEnd()
+
+	// Check for missing tool result issue
+	issues := validator.GetIssues()
+	if len(issues) != 2 {
+		t.Errorf("Expected 2 issues (missing tool result + missing result message), got %d", len(issues))
+	}
+
+	foundMissingTool := false
+	for _, issue := range issues {
+		if issue.Type == "missing_tool_result" && issue.ToolUseID == "tool_123" {
+			foundMissingTool = true
+		}
+	}
+	if !foundMissingTool {
+		t.Error("Expected missing_tool_result issue for tool_123")
+	}
+
+	// Validate stats
+	stats := validator.GetStats()
+	if stats.ToolsRequested != 1 {
+		t.Errorf("Expected 1 tool requested, got %d", stats.ToolsRequested)
+	}
+	if stats.ToolsReceived != 0 {
+		t.Errorf("Expected 0 tools received, got %d", stats.ToolsReceived)
+	}
+	if len(stats.PendingTools) != 1 {
+		t.Errorf("Expected 1 pending tool, got %d", len(stats.PendingTools))
+	}
+}
+
+func TestStreamValidator_ExtraToolResult(t *testing.T) {
+	validator := NewStreamValidator()
+
+	// Simulate tool result without request
+	userMsg := &UserMessage{
+		Content: []ContentBlock{
+			&ToolResultBlock{
+				ToolUseID: "tool_999",
+				Content:   "unexpected result",
+			},
+		},
+	}
+
+	validator.TrackMessage(userMsg)
+	validator.MarkStreamEnd()
+
+	// Check for extra tool result issue
+	issues := validator.GetIssues()
+	if len(issues) != 1 {
+		t.Errorf("Expected 1 issue, got %d", len(issues))
+	}
+
+	if issues[0].Type != "extra_tool_result" {
+		t.Errorf("Expected extra_tool_result issue, got %s", issues[0].Type)
+	}
+	if issues[0].ToolUseID != "tool_999" {
+		t.Errorf("Expected tool_999, got %s", issues[0].ToolUseID)
+	}
+}
+
+func TestStreamValidator_MultipleTools(t *testing.T) {
+	validator := NewStreamValidator()
+
+	// Track multiple tools
+	assistantMsg := &AssistantMessage{
+		Content: []ContentBlock{
+			&ToolUseBlock{ToolUseID: "tool_1", Name: "read_file"},
+			&ToolUseBlock{ToolUseID: "tool_2", Name: "write_file"},
+			&ToolUseBlock{ToolUseID: "tool_3", Name: "list_files"},
+		},
+	}
+
+	userMsg := &UserMessage{
+		Content: []ContentBlock{
+			&ToolResultBlock{ToolUseID: "tool_1", Content: "result1"},
+			&ToolResultBlock{ToolUseID: "tool_2", Content: "result2"},
+			&ToolResultBlock{ToolUseID: "tool_3", Content: "result3"},
+		},
+	}
+
+	resultMsg := &ResultMessage{}
+
+	validator.TrackMessage(assistantMsg)
+	validator.TrackMessage(userMsg)
+	validator.TrackMessage(resultMsg)
+	validator.MarkStreamEnd()
+
+	// Validate complete stream
+	issues := validator.GetIssues()
+	if len(issues) != 0 {
+		t.Errorf("Expected no issues, got %d: %+v", len(issues), issues)
+	}
+
+	stats := validator.GetStats()
+	if stats.ToolsRequested != 3 {
+		t.Errorf("Expected 3 tools requested, got %d", stats.ToolsRequested)
+	}
+	if stats.ToolsReceived != 3 {
+		t.Errorf("Expected 3 tools received, got %d", stats.ToolsReceived)
+	}
+	if len(stats.PendingTools) != 0 {
+		t.Errorf("Expected no pending tools, got %d", len(stats.PendingTools))
+	}
+}
+
+func TestStreamValidator_MissingResultMessage(t *testing.T) {
+	validator := NewStreamValidator()
+
+	// Complete tool cycle but no result message
+	assistantMsg := &AssistantMessage{
+		Content: []ContentBlock{
+			&ToolUseBlock{ToolUseID: "tool_1", Name: "read_file"},
+		},
+	}
+
+	userMsg := &UserMessage{
+		Content: []ContentBlock{
+			&ToolResultBlock{ToolUseID: "tool_1", Content: "result"},
+		},
+	}
+
+	validator.TrackMessage(assistantMsg)
+	validator.TrackMessage(userMsg)
+	validator.MarkStreamEnd()
+
+	// Check for missing result message
+	issues := validator.GetIssues()
+	if len(issues) != 1 {
+		t.Errorf("Expected 1 issue, got %d", len(issues))
+	}
+
+	if issues[0].Type != "missing_result_message" {
+		t.Errorf("Expected missing_result_message, got %s", issues[0].Type)
+	}
+
+	stats := validator.GetStats()
+	if stats.HasResult {
+		t.Error("Expected HasResult to be false")
+	}
+}
+
+func TestStreamValidator_ThreadSafety(t *testing.T) {
+	validator := NewStreamValidator()
+	var wg sync.WaitGroup
+
+	// Simulate concurrent message tracking
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			// Each goroutine tracks a tool request and result
+			assistantMsg := &AssistantMessage{
+				Content: []ContentBlock{
+					&ToolUseBlock{
+						ToolUseID: "tool_" + string(rune('0'+id)),
+						Name:      "test",
+					},
+				},
+			}
+
+			userMsg := &UserMessage{
+				Content: []ContentBlock{
+					&ToolResultBlock{
+						ToolUseID: "tool_" + string(rune('0'+id)),
+						Content:   "result",
+					},
+				},
+			}
+
+			validator.TrackMessage(assistantMsg)
+			validator.TrackMessage(userMsg)
+
+			// Also read stats concurrently
+			_ = validator.GetStats()
+			_ = validator.GetIssues()
+		}(i)
+	}
+
+	wg.Wait()
+	validator.MarkStreamEnd()
+
+	// Verify all tools tracked correctly
+	stats := validator.GetStats()
+	if stats.ToolsRequested != 10 {
+		t.Errorf("Expected 10 tools requested, got %d", stats.ToolsRequested)
+	}
+	if stats.ToolsReceived != 10 {
+		t.Errorf("Expected 10 tools received, got %d", stats.ToolsReceived)
+	}
+}
+
+func TestStreamValidator_PartialCompletion(t *testing.T) {
+	validator := NewStreamValidator()
+
+	// Request 3 tools, receive 2
+	assistantMsg := &AssistantMessage{
+		Content: []ContentBlock{
+			&ToolUseBlock{ToolUseID: "tool_1", Name: "read_file"},
+			&ToolUseBlock{ToolUseID: "tool_2", Name: "write_file"},
+			&ToolUseBlock{ToolUseID: "tool_3", Name: "list_files"},
+		},
+	}
+
+	userMsg := &UserMessage{
+		Content: []ContentBlock{
+			&ToolResultBlock{ToolUseID: "tool_1", Content: "result1"},
+			&ToolResultBlock{ToolUseID: "tool_2", Content: "result2"},
+			// tool_3 result missing
+		},
+	}
+
+	validator.TrackMessage(assistantMsg)
+	validator.TrackMessage(userMsg)
+	validator.MarkStreamEnd()
+
+	// Check for missing tool result
+	issues := validator.GetIssues()
+	if len(issues) != 2 {
+		t.Errorf("Expected 2 issues, got %d", len(issues))
+	}
+
+	foundMissingTool := false
+	for _, issue := range issues {
+		if issue.Type == "missing_tool_result" && issue.ToolUseID == "tool_3" {
+			foundMissingTool = true
+		}
+	}
+	if !foundMissingTool {
+		t.Error("Expected missing_tool_result issue for tool_3")
+	}
+
+	stats := validator.GetStats()
+	if stats.ToolsRequested != 3 {
+		t.Errorf("Expected 3 tools requested, got %d", stats.ToolsRequested)
+	}
+	if stats.ToolsReceived != 2 {
+		t.Errorf("Expected 2 tools received, got %d", stats.ToolsReceived)
+	}
+	if len(stats.PendingTools) != 1 {
+		t.Errorf("Expected 1 pending tool, got %d", len(stats.PendingTools))
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -819,6 +819,7 @@ func (m *mockTransportForOptions) ReceiveMessages(_ context.Context) (<-chan Mes
 }
 func (m *mockTransportForOptions) Interrupt(_ context.Context) error { return nil }
 func (m *mockTransportForOptions) Close() error                      { return nil }
+func (m *mockTransportForOptions) GetValidator() *StreamValidator    { return &StreamValidator{} }
 
 // TestWithEnvOptions tests environment variable functional options following table-driven pattern
 func TestWithEnvOptions(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -926,6 +926,10 @@ func (q *queryMockTransport) Close() error {
 	return nil
 }
 
+func (q *queryMockTransport) GetValidator() *StreamValidator {
+	return &StreamValidator{}
+}
+
 // Mock helper methods
 
 func (q *queryMockTransport) hasReceivedOptions() bool {

--- a/types.go
+++ b/types.go
@@ -45,6 +45,15 @@ type StreamMessage = shared.StreamMessage
 // MessageIterator provides iteration over messages.
 type MessageIterator = shared.MessageIterator
 
+// StreamValidator tracks tool requests and results to detect incomplete streams.
+type StreamValidator = shared.StreamValidator
+
+// StreamIssue represents a validation issue found in the stream.
+type StreamIssue = shared.StreamIssue
+
+// StreamStats provides statistics about the message stream.
+type StreamStats = shared.StreamStats
+
 // Re-export message type constants
 const (
 	MessageTypeUser      = shared.MessageTypeUser
@@ -79,4 +88,5 @@ type Transport interface {
 	ReceiveMessages(ctx context.Context) (<-chan Message, <-chan error)
 	Interrupt(ctx context.Context) error
 	Close() error
+	GetValidator() *StreamValidator
 }


### PR DESCRIPTION
Rebased version of #22 to resolve conflicts with merged PRs.

## Overview
Adds a stream validation system to track tool requests and results, helping detect incomplete streams caused by subprocess crashes or other failures.

## New Components
- **StreamValidator**: Tracks tool_use and tool_result messages
- **StreamIssue**: Represents validation problems found
- **StreamStats**: Provides stream statistics

## Client API
```go
// Get validation issues after stream completes
issues := client.GetStreamIssues()

// Get stream statistics
stats := client.GetStreamStats()
```

## Capabilities
- Detects missing tool results
- Detects extra/unexpected tool results
- Detects missing result messages
- Thread-safe concurrent access

## Testing
- 7 comprehensive test cases covering all scenarios
- Thread safety verification
- Edge cases (partial completion, multiple tools, etc.)

See #22 for original discussion.