### PR TITLE
fix: remove discussion_category_name from goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,6 @@ release:
   github:
     owner: severity1
     name: claude-code-sdk-go
-  discussion_category_name: General
   prerelease: auto
   mode: replace
   header: |


### PR DESCRIPTION
## Summary
- Remove `discussion_category_name: General` from goreleaser config

## Problem
The release pipeline was failing with:
```
error=scm releases: failed to publish artifacts: could not release: PATCH https://api.github.com/repos/severity1/claude-code-sdk-go/releases/271929060: 404 Discussions are not enabled on this repository. []
```

## Solution
Remove the `discussion_category_name` setting since GitHub Discussions is not enabled on this repository.

## Test plan
- [ ] Re-run release workflow after merge