### PR TITLE
feat: Add tools preset and ToolsPreset type (Issue #27)

### DIFF
--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -135,6 +136,7 @@ func BuildCommandWithPrompt(cliPath string, options *shared.Options, prompt stri
 // addOptionsToCommand adds all Options fields as CLI flags
 func addOptionsToCommand(cmd []string, options *shared.Options) []string {
 	cmd = addToolControlFlags(cmd, options)
+	cmd = addToolsFlag(cmd, options)
 	cmd = addModelAndPromptFlags(cmd, options)
 	cmd = addPermissionFlags(cmd, options)
 	cmd = addSessionFlags(cmd, options)
@@ -151,6 +153,26 @@ func addToolControlFlags(cmd []string, options *shared.Options) []string {
 	}
 	if len(options.DisallowedTools) > 0 {
 		cmd = append(cmd, "--disallowed-tools", strings.Join(options.DisallowedTools, ","))
+	}
+	return cmd
+}
+
+func addToolsFlag(cmd []string, options *shared.Options) []string {
+	if options.Tools == nil {
+		return cmd
+	}
+
+	switch v := options.Tools.(type) {
+	case []string:
+		if len(v) > 0 {
+			cmd = append(cmd, "--tools", strings.Join(v, ","))
+		}
+	case shared.ToolsPreset:
+		// Serialize as JSON for preset
+		data, err := json.Marshal(v)
+		if err == nil {
+			cmd = append(cmd, "--tools", string(data))
+		}
 	}
 	return cmd
 }

--- a/internal/shared/options.go
+++ b/internal/shared/options.go
@@ -30,11 +30,21 @@ const (
 	SdkBetaContext1M SdkBeta = "context-1m-2025-08-07"
 )
 
+// ToolsPreset represents a preset tools configuration.
+type ToolsPreset struct {
+	Type   string `json:"type"`   // Always "preset"
+	Preset string `json:"preset"` // e.g., "claude_code"
+}
+
 // Options configures the Claude Code SDK behavior.
 type Options struct {
 	// Tool Control
 	AllowedTools    []string `json:"allowed_tools,omitempty"`
 	DisallowedTools []string `json:"disallowed_tools,omitempty"`
+
+	// Tools configures available tools.
+	// Can be []string (list of tool names) or ToolsPreset (preset configuration).
+	Tools any `json:"tools,omitempty"`
 
 	// Beta Features
 	Betas []SdkBeta `json:"betas,omitempty"`

--- a/options.go
+++ b/options.go
@@ -28,6 +28,9 @@ type McpHTTPServerConfig = shared.McpHTTPServerConfig
 // SdkBeta represents a beta feature identifier.
 type SdkBeta = shared.SdkBeta
 
+// ToolsPreset represents a preset tools configuration.
+type ToolsPreset = shared.ToolsPreset
+
 // Re-export constants
 const (
 	PermissionModeDefault           = shared.PermissionModeDefault
@@ -55,6 +58,28 @@ func WithDisallowedTools(tools ...string) Option {
 	return func(o *Options) {
 		o.DisallowedTools = tools
 	}
+}
+
+// WithTools sets available tools as a list of tool names.
+func WithTools(tools ...string) Option {
+	return func(o *Options) {
+		o.Tools = tools
+	}
+}
+
+// WithToolsPreset sets tools to a preset configuration.
+func WithToolsPreset(preset string) Option {
+	return func(o *Options) {
+		o.Tools = ToolsPreset{
+			Type:   "preset",
+			Preset: preset,
+		}
+	}
+}
+
+// WithClaudeCodeTools sets tools to the claude_code preset.
+func WithClaudeCodeTools() Option {
+	return WithToolsPreset("claude_code")
 }
 
 // WithSystemPrompt sets the system prompt.


### PR DESCRIPTION
## Summary

Add `Tools` option supporting both tool list and preset configuration, providing a flexible way to configure available tools.

## Changes

### Files Created
- None

### Files Modified
- `internal/shared/options.go` - Add `ToolsPreset` struct and `Tools` field to Options
- `options.go` - Add `WithTools()`, `WithToolsPreset()`, `WithClaudeCodeTools()` functional options and re-export `ToolsPreset` type
- `internal/cli/discovery.go` - Add `addToolsFlag()` for CLI flag generation
- `options_test.go` - Add tests for new functional options
- `internal/cli/discovery_test.go` - Add tests for CLI flag generation

## Test Plan
- [x] All tests passing (`go test ./...`)
- [x] Coverage maintained (86.0% main package, 94.9% CLI package)
- [x] Race detector clean (`go test -race ./...`)
- [x] Linting clean (`golangci-lint run`)

## TDD Cycle
- RED: Tests written first (failing because types/functions don't exist)
- GREEN: Implementation added to make tests pass
- BLUE: Code formatted and linted

## Example Usage

```go
// Use tool list
options := claudecode.NewOptions(
    claudecode.WithTools("Read", "Write", "Edit"),
)

// Use preset
options := claudecode.NewOptions(
    claudecode.WithToolsPreset("claude_code"),
)

// Use convenience function for claude_code preset
options := claudecode.NewOptions(
    claudecode.WithClaudeCodeTools(),
)
```

Closes #27