### PR TITLE
fix: change ResultMessage.Result type from map to string (Issue #18)

### DIFF
--- a/internal/parser/json.go
+++ b/internal/parser/json.go
@@ -299,8 +299,8 @@ func (p *Parser) parseResultMessage(data map[string]any) (*shared.ResultMessage,
 	}
 
 	if resultData, ok := data["result"]; ok {
-		if resultMap, ok := resultData.(map[string]any); ok {
-			result.Result = &resultMap
+		if resultStr, ok := resultData.(string); ok {
+			result.Result = &resultStr
 		}
 	}
 

--- a/internal/parser/json_test.go
+++ b/internal/parser/json_test.go
@@ -755,7 +755,7 @@ func TestResultMessageOptionalFields(t *testing.T) {
 	}
 	dataWithOptionals["total_cost_usd"] = 0.05
 	dataWithOptionals["usage"] = map[string]any{"input_tokens": 100}
-	dataWithOptionals["result"] = map[string]any{"status": "success"}
+	dataWithOptionals["result"] = "The answer is 42"
 
 	msg, err := parser.ParseMessage(dataWithOptionals)
 	assertNoParseError(t, err)
@@ -770,13 +770,16 @@ func TestResultMessageOptionalFields(t *testing.T) {
 	if resultMsg.Result == nil {
 		t.Error("Expected result field to be set")
 	}
+	if *resultMsg.Result != "The answer is 42" {
+		t.Errorf("Expected result = 'The answer is 42', got %v", *resultMsg.Result)
+	}
 
-	// Test with invalid result type (not map)
+	// Test with invalid result type (not string)
 	dataWithInvalidResult := make(map[string]any)
 	for k, v := range baseData {
 		dataWithInvalidResult[k] = v
 	}
-	dataWithInvalidResult["result"] = "not a map"
+	dataWithInvalidResult["result"] = map[string]any{"not": "a string"}
 
 	msg2, err2 := parser.ParseMessage(dataWithInvalidResult)
 	assertNoParseError(t, err2)

--- a/internal/shared/message.go
+++ b/internal/shared/message.go
@@ -163,7 +163,7 @@ type ResultMessage struct {
 	SessionID     string          `json:"session_id"`
 	TotalCostUSD  *float64        `json:"total_cost_usd,omitempty"`
 	Usage         *map[string]any `json:"usage,omitempty"`
-	Result        *map[string]any `json:"result,omitempty"`
+	Result        *string         `json:"result,omitempty"`
 }
 
 // Type returns the message type for ResultMessage.


### PR DESCRIPTION
## Summary

- Changed `ResultMessage.Result` type from `*map[string]any` to `*string` to match the Python SDK
- Updated parser to correctly extract string values from CLI output
- Updated tests to verify string parsing

## Background

The Claude Code CLI returns `result` as a string (e.g., `"result": "The answer is 42"`), but the Go SDK was expecting a map. This caused the `Result` field to always be `nil`, silently dropping the actual result value.

Verified with live CLI output (v2.0.67):
```json
{
  "result": "4",
  "result_type": "string",
  "is_error": false
}
```

## Test plan

- [x] All existing tests pass
- [x] Updated parser tests verify string extraction
- [x] Build passes
- [x] Linter passes

Fixes #18