### PR TITLE
feat: Add plugins configuration support (Issue #34)

### DIFF
--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -142,6 +142,7 @@ func addOptionsToCommand(cmd []string, options *shared.Options) []string {
 	cmd = addSessionFlags(cmd, options)
 	cmd = addFileSystemFlags(cmd, options)
 	cmd = addMCPFlags(cmd, options)
+	cmd = addPluginsFlag(cmd, options)
 	cmd = addBetasFlag(cmd, options)
 	cmd = addExtraFlags(cmd, options)
 	return cmd
@@ -264,6 +265,16 @@ func addBetasFlag(cmd []string, options *shared.Options) []string {
 			betaStrs[i] = string(beta)
 		}
 		cmd = append(cmd, "--betas", strings.Join(betaStrs, ","))
+	}
+	return cmd
+}
+
+func addPluginsFlag(cmd []string, options *shared.Options) []string {
+	for _, plugin := range options.Plugins {
+		if plugin.Type == shared.SdkPluginTypeLocal {
+			cmd = append(cmd, "--plugin-dir", plugin.Path)
+		}
+		// Note: Future plugin types would be handled here
 	}
 	return cmd
 }

--- a/internal/shared/options.go
+++ b/internal/shared/options.go
@@ -48,6 +48,22 @@ const (
 	SettingSourceLocal SettingSource = "local"
 )
 
+// SdkPluginType represents the type of SDK plugin.
+type SdkPluginType string
+
+const (
+	// SdkPluginTypeLocal represents a local plugin loaded from the filesystem.
+	SdkPluginTypeLocal SdkPluginType = "local"
+)
+
+// SdkPluginConfig represents a plugin configuration.
+type SdkPluginConfig struct {
+	// Type is the plugin type (currently only "local" is supported).
+	Type SdkPluginType `json:"type"`
+	// Path is the filesystem path to the plugin directory.
+	Path string `json:"path"`
+}
+
 // Options configures the Claude Code SDK behavior.
 type Options struct {
 	// Tool Control
@@ -93,6 +109,9 @@ type Options struct {
 
 	// MCP Integration
 	McpServers map[string]McpServerConfig `json:"mcp_servers,omitempty"`
+
+	// Plugin Configurations
+	Plugins []SdkPluginConfig `json:"plugins,omitempty"`
 
 	// Extensibility
 	ExtraArgs map[string]*string `json:"extra_args,omitempty"`
@@ -195,6 +214,7 @@ func NewOptions() *Options {
 		MaxThinkingTokens: DefaultMaxThinkingTokens,
 		AddDirs:           []string{},
 		McpServers:        make(map[string]McpServerConfig),
+		Plugins:           []SdkPluginConfig{},
 		ExtraArgs:         make(map[string]*string),
 		ExtraEnv:          make(map[string]string),
 		SettingSources:    []SettingSource{},

--- a/options.go
+++ b/options.go
@@ -34,6 +34,12 @@ type ToolsPreset = shared.ToolsPreset
 // SettingSource represents a settings source location.
 type SettingSource = shared.SettingSource
 
+// SdkPluginType represents the type of SDK plugin.
+type SdkPluginType = shared.SdkPluginType
+
+// SdkPluginConfig represents a plugin configuration.
+type SdkPluginConfig = shared.SdkPluginConfig
+
 // Re-export constants
 const (
 	PermissionModeDefault           = shared.PermissionModeDefault
@@ -47,6 +53,7 @@ const (
 	SettingSourceUser               = shared.SettingSourceUser
 	SettingSourceProject            = shared.SettingSourceProject
 	SettingSourceLocal              = shared.SettingSourceLocal
+	SdkPluginTypeLocal              = shared.SdkPluginTypeLocal
 )
 
 // Option configures Options using the functional options pattern.
@@ -269,6 +276,33 @@ func WithEnvVar(key, value string) Option {
 func WithBetas(betas ...SdkBeta) Option {
 	return func(o *Options) {
 		o.Betas = betas
+	}
+}
+
+// WithPlugins sets the plugin configurations.
+// This replaces any previously configured plugins.
+func WithPlugins(plugins []SdkPluginConfig) Option {
+	return func(o *Options) {
+		o.Plugins = plugins
+	}
+}
+
+// WithPlugin appends a single plugin configuration.
+// Multiple calls accumulate plugins.
+func WithPlugin(plugin SdkPluginConfig) Option {
+	return func(o *Options) {
+		o.Plugins = append(o.Plugins, plugin)
+	}
+}
+
+// WithLocalPlugin appends a local plugin by path.
+// This is a convenience method for the common case of local plugins.
+func WithLocalPlugin(path string) Option {
+	return func(o *Options) {
+		o.Plugins = append(o.Plugins, SdkPluginConfig{
+			Type: SdkPluginTypeLocal,
+			Path: path,
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Add `plugins` option for custom plugin configurations to achieve 100% Python SDK parity. Currently only local plugins are supported via the `local` type.

## Changes

### Files Created
- None (all modifications to existing files)

### Files Modified
- `internal/shared/options.go` - Add SdkPluginType, SdkPluginConfig types, and Plugins field
- `options.go` - Add type aliases, constant, and functional options (WithPlugins, WithPlugin, WithLocalPlugin)
- `internal/cli/discovery.go` - Add addPluginsFlag helper to generate --plugin-dir CLI flags
- `options_test.go` - Add comprehensive tests for plugin functional options
- `internal/cli/discovery_test.go` - Add tests for CLI flag generation

## Test Plan
- [x] All tests passing
- [x] Coverage maintained (86.5% overall)
- [x] Race detector clean
- [x] Python SDK parity verified

## TDD Cycle
- RED: Tests written first (compile errors expected - types don't exist)
- GREEN: Implementation added (b864f39)
- BLUE: Linters pass, no refactoring needed

## Example Usage

```go
// Using WithPlugins to set all plugins at once
plugins := []claudecode.SdkPluginConfig{
    {
        Type: claudecode.SdkPluginTypeLocal,
        Path: "/path/to/my-plugin",
    },
}
client := claudecode.NewClient(claudecode.WithPlugins(plugins))

// Or using convenience function for local plugins
client := claudecode.NewClient(
    claudecode.WithLocalPlugin("/path/to/plugin1"),
    claudecode.WithLocalPlugin("/path/to/plugin2"),
)
```

Closes #34