### PR TITLE
feat: Add stderr callback for CLI output streaming (Issue #53)

### DIFF
--- a/internal/shared/options.go
+++ b/internal/shared/options.go
@@ -219,6 +219,13 @@ type Options struct {
 	// If nil (default), stderr is isolated to a temporary file to prevent deadlocks.
 	// Common values: os.Stderr, io.Discard, or a custom io.Writer.
 	DebugWriter io.Writer `json:"-"` // Not serialized
+
+	// StderrCallback receives CLI stderr output line-by-line.
+	// If set, takes precedence over DebugWriter for stderr handling.
+	// Each line is stripped of trailing whitespace and empty lines are skipped.
+	// Callback panics are silently recovered to prevent crashing the SDK.
+	// Matches Python SDK's stderr callback behavior.
+	StderrCallback func(string) `json:"-"` // Not serialized
 }
 
 // McpServerType represents the type of MCP server.

--- a/internal/subprocess/transport_test.go
+++ b/internal/subprocess/transport_test.go
@@ -1290,7 +1290,7 @@ func TestStderrCallbackPanicRecovery(t *testing.T) {
 	panicCount := 0
 	var mu sync.Mutex
 
-	callback := func(line string) {
+	callback := func(_ string) {
 		mu.Lock()
 		panicCount++
 		mu.Unlock()
@@ -1338,7 +1338,7 @@ func TestStderrCallbackPrecedence(t *testing.T) {
 
 			callbackCalled := false
 			if tt.hasCallback {
-				options.StderrCallback = func(line string) {
+				options.StderrCallback = func(_ string) {
 					callbackCalled = true
 				}
 			}
@@ -1397,7 +1397,7 @@ func TestStderrCallbackWithMockCLI(t *testing.T) {
 
 	// Create a mock CLI that outputs to stderr
 	cliPath := newTransportMockCLIWithStderr()
-	defer os.Remove(cliPath)
+	defer func() { _ = os.Remove(cliPath) }()
 
 	transport := New(cliPath, options, false, "sdk-go")
 	defer disconnectTransportSafely(t, transport)

--- a/options.go
+++ b/options.go
@@ -441,6 +441,18 @@ func WithDebugDisabled() Option {
 	return WithDebugWriter(io.Discard)
 }
 
+// WithStderrCallback sets a callback for receiving CLI stderr output.
+// The callback is invoked for each non-empty line of stderr output.
+// Lines are stripped of trailing whitespace before being passed to the callback.
+// This takes precedence over WithDebugWriter if both are set.
+// Callback panics are silently recovered to prevent crashing the SDK.
+// Matches Python SDK's stderr callback behavior.
+func WithStderrCallback(callback func(string)) Option {
+	return func(o *Options) {
+		o.StderrCallback = callback
+	}
+}
+
 // OutputFormatJSONSchema creates an OutputFormat for JSON schema constraints.
 func OutputFormatJSONSchema(schema map[string]any) *OutputFormat {
 	return &OutputFormat{

--- a/options_test.go
+++ b/options_test.go
@@ -2699,7 +2699,7 @@ func TestWithStderrCallback(t *testing.T) {
 		{
 			name: "callback_set",
 			setup: func() *Options {
-				return NewOptions(WithStderrCallback(func(line string) {}))
+				return NewOptions(WithStderrCallback(func(_ string) {}))
 			},
 			validate: func(t *testing.T, options *Options) {
 				t.Helper()
@@ -2716,14 +2716,14 @@ func TestWithStderrCallback(t *testing.T) {
 			validate: func(t *testing.T, options *Options) {
 				t.Helper()
 				if options.StderrCallback != nil {
-					t.Errorf("Expected StderrCallback to be nil by default, got %v", options.StderrCallback)
+					t.Error("Expected StderrCallback to be nil by default")
 				}
 			},
 		},
 		{
 			name: "callback_invocation",
 			setup: func() *Options {
-				return NewOptions(WithStderrCallback(func(line string) {
+				return NewOptions(WithStderrCallback(func(_ string) {
 					// Verify callback is invocable by checking it compiles
 				}))
 			},
@@ -2758,11 +2758,9 @@ func TestWithStderrCallback(t *testing.T) {
 		{
 			name: "override_previous_callback",
 			setup: func() *Options {
-				firstCalled := false
-				secondCalled := false
 				return NewOptions(
-					WithStderrCallback(func(line string) { firstCalled = true }),
-					WithStderrCallback(func(line string) { secondCalled = true }), // Should win
+					WithStderrCallback(func(_ string) { /* first */ }),
+					WithStderrCallback(func(_ string) { /* second wins */ }),
 				)
 			},
 			validate: func(t *testing.T, options *Options) {
@@ -2780,7 +2778,7 @@ func TestWithStderrCallback(t *testing.T) {
 			validate: func(t *testing.T, options *Options) {
 				t.Helper()
 				if options.StderrCallback != nil {
-					t.Errorf("Expected StderrCallback to be nil when explicitly set, got %v", options.StderrCallback)
+					t.Error("Expected StderrCallback to be nil when explicitly set")
 				}
 			},
 		},
@@ -2801,7 +2799,7 @@ func TestStderrCallbackIntegration(t *testing.T) {
 	options := NewOptions(
 		WithSystemPrompt("You are a helpful assistant"),
 		WithDebugWriter(&debugBuf),
-		WithStderrCallback(func(line string) {}),
+		WithStderrCallback(func(_ string) {}),
 		WithModel("claude-3-5-sonnet-20241022"),
 		WithPermissionMode(PermissionModeAcceptEdits),
 	)
@@ -2828,7 +2826,7 @@ func TestStderrCallbackIndependentOfDebugWriter(t *testing.T) {
 		var buf bytes.Buffer
 		options := NewOptions(
 			WithDebugWriter(&buf),
-			WithStderrCallback(func(line string) {}),
+			WithStderrCallback(func(_ string) {}),
 		)
 
 		if options.DebugWriter == nil {
@@ -2840,7 +2838,7 @@ func TestStderrCallbackIndependentOfDebugWriter(t *testing.T) {
 	})
 
 	t.Run("only_callback", func(t *testing.T) {
-		options := NewOptions(WithStderrCallback(func(line string) {}))
+		options := NewOptions(WithStderrCallback(func(_ string) {}))
 
 		if options.DebugWriter != nil {
 			t.Error("Expected DebugWriter to be nil")


### PR DESCRIPTION
## Summary

Add `WithStderrCallback()` option for receiving CLI stderr output via callback function, matching the Python SDK's `stderr` callback behavior with 100% parity.

## Changes

### Files Created
None

### Files Modified
- `internal/shared/options.go` - Add `StderrCallback func(string)` field to Options struct
- `options.go` - Add `WithStderrCallback(callback func(string)) Option` functional option
- `options_test.go` - Add comprehensive table-driven tests for StderrCallback option
- `internal/subprocess/transport.go` - Implement `handleStderrCallback()` goroutine with precedence logic
- `internal/subprocess/transport_test.go` - Add transport-level tests for stderr callback

## Implementation Details

### Precedence Logic
`StderrCallback > DebugWriter > temp file (default)`

### Python SDK Parity
| Python Behavior | Go Implementation |
|-----------------|-------------------|
| `stderr: Callable[[str], None]` | `StderrCallback func(string)` |
| Line-by-line processing | `bufio.Scanner` in goroutine |
| `line.rstrip()` | `strings.TrimRight(line, " \t\r\n")` |
| Skip empty lines | `if line == "" { continue }` |
| Synchronous callback | Direct call in goroutine |
| `except Exception: pass` | `recover()` + ignore scanner errors |
| Separate async task | `go t.handleStderrCallback()` with `wg.Add(1)` |

## Test Plan
- [x] All tests passing
- [x] Coverage maintained (88.1% main, 78.0% subprocess)
- [x] Race detector clean
- [x] Python SDK parity verified
- [x] Linter passing (golangci-lint)

## TDD Cycle
- RED: Tests written first (commit b9c3b78)
- GREEN: Implementation added (commit 32002ce)

Closes #53