### PR TITLE
fix: pass --tools "" for explicitly empty tools list

### DIFF
--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -178,9 +178,9 @@ func addToolsFlag(cmd []string, options *shared.Options) []string {
 
 	switch v := options.Tools.(type) {
 	case []string:
-		if len(v) > 0 {
-			cmd = append(cmd, "--tools", strings.Join(v, ","))
-		}
+		// Pass --tools "" for explicitly empty list (disables all tools)
+		// vs nil which means "use default tools"
+		cmd = append(cmd, "--tools", strings.Join(v, ","))
 	case shared.ToolsPreset:
 		// Serialize as JSON for preset
 		data, err := json.Marshal(v)

--- a/internal/cli/discovery_test.go
+++ b/internal/cli/discovery_test.go
@@ -765,7 +765,7 @@ func TestToolsFlagSupport(t *testing.T) {
 			options: &shared.Options{
 				Tools: []string{},
 			},
-			validate: validateNoToolsFlag,
+			validate: validateEmptyToolsFlag,
 		},
 	}
 
@@ -804,6 +804,14 @@ func validateToolsPresetFlag(t *testing.T, cmd []string) {
 func validateNoToolsFlag(t *testing.T, cmd []string) {
 	t.Helper()
 	assertNotContainsArg(t, cmd, "--tools")
+}
+
+// validateEmptyToolsFlag checks that --tools flag is present with empty string value
+// This is important because --tools "" explicitly disables all tools,
+// which is different from nil (use default tools).
+func validateEmptyToolsFlag(t *testing.T, cmd []string) {
+	t.Helper()
+	assertContainsArgs(t, cmd, "--tools", "")
 }
 
 // TestSessionManagementFlagsSupport tests fork_session and setting_sources CLI flags


### PR DESCRIPTION
## Summary
- Match Python SDK behavior for empty tools list handling
- Empty slice (`[]string{}`) now passes `--tools ""` to CLI
- `nil` Tools still does not pass the flag at all
- This allows users to explicitly disable all tools

## Test plan
- [x] Verify `tools_empty_list` test case passes with `--tools ""`
- [x] Verify `tools_nil` test case still works (no flag passed)
- [x] Verify `tools_list` test case still works (comma-separated tools)
- [x] Run `go test ./internal/cli/...` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)