### PR TITLE
fix: Handle initialization errors in control protocol and enhance Res…

### DIFF
--- a/internal/control/protocol.go
+++ b/internal/control/protocol.go
@@ -39,6 +39,7 @@ type Protocol struct {
 	// State
 	initialized  bool
 	initResponse *InitializeResponse
+	initErrChan  chan error
 	closed       bool
 	started      bool
 
@@ -112,6 +113,7 @@ func NewProtocol(transport Transport, opts ...ProtocolOption) *Protocol {
 		pendingRequests: make(map[string]chan *Response),
 		messageStream:   make(chan map[string]any, 100),
 		initTimeout:     DefaultInitTimeout,
+		initErrChan:     make(chan error, 1),
 	}
 
 	for _, opt := range opts {
@@ -237,6 +239,9 @@ func (p *Protocol) SendControlRequest(ctx context.Context, request any, timeout 
 		}
 		return response.Response, nil
 
+	case err := <-p.initErrChan:
+		return nil, err
+
 	case <-timeoutCtx.Done():
 		return nil, fmt.Errorf("control request timeout: %w", timeoutCtx.Err())
 	}
@@ -260,6 +265,14 @@ func (p *Protocol) HandleIncomingMessage(ctx context.Context, msg map[string]any
 	default:
 		// Regular SDK message - forward to stream
 		return p.forwardToStream(ctx, msg)
+	}
+}
+
+// HandleControlInitErr allows reporting initialization errors back to the main client.
+func (p *Protocol) HandleControlInitErr(err error) {
+	select {
+	case p.initErrChan <- err:
+	default:
 	}
 }
 

--- a/internal/parser/json.go
+++ b/internal/parser/json.go
@@ -268,6 +268,13 @@ func (p *Parser) parseSystemMessage(data map[string]any) (*shared.SystemMessage,
 func (p *Parser) parseResultMessage(data map[string]any) (*shared.ResultMessage, error) {
 	result := &shared.ResultMessage{}
 
+	bs, err := json.Marshal(data)
+	if err != nil {
+		return nil, shared.NewMessageParseError("result message missing data", data)
+	}
+	// common fields are optional and can be populated directly from the JSON without validation errors, following the Python SDK pattern
+	_ = json.Unmarshal(bs, result)
+
 	// Required fields with validation
 	if subtype, ok := data["subtype"].(string); ok {
 		result.Subtype = subtype

--- a/internal/shared/message.go
+++ b/internal/shared/message.go
@@ -177,6 +177,7 @@ type ResultMessage struct {
 	DurationMs       int             `json:"duration_ms"`
 	DurationAPIMs    int             `json:"duration_api_ms"`
 	IsError          bool            `json:"is_error"`
+	Errors           []string        `json:"errors"`
 	NumTurns         int             `json:"num_turns"`
 	SessionID        string          `json:"session_id"`
 	TotalCostUSD     *float64        `json:"total_cost_usd,omitempty"`

--- a/internal/subprocess/io.go
+++ b/internal/subprocess/io.go
@@ -55,6 +55,16 @@ func (t *Transport) handleStdout() {
 				continue
 			}
 
+			// if this is a ResultMessage and we're not connected yet, it may be an initial connection message that we should ignore for stream validation
+			if resultMsg, ok := msg.(*shared.ResultMessage); ok && !t.connected && resultMsg.IsError {
+				// Route control messages to the controlProtocol for request/response correlation
+				if t.protocol != nil {
+					// HandleIncomingMessage routes control responses to pending requests
+					// and forwards non-control messages to the controlProtocol's message stream
+					t.protocol.HandleControlInitErr(fmt.Errorf("control protocol not yet initialized, %v", resultMsg.Errors))
+				}
+			}
+
 			// Check if this is a control message that should be routed to the protocol
 			if rawCtrl, ok := msg.(*shared.RawControlMessage); ok {
 				// Route control messages to the protocol for request/response correlation


### PR DESCRIPTION
When Claude Code boots with an invalid session ID, it immediately returns a 'result' message. We need to parse and return this message during control init to prevent the process from hanging.

eg:
```
start claude process: failed to connect transport: failed to initialize control controlProtocol: initialize failed: control protocol not yet initialized, [No conversation found with session ID: e83926ec-138d-47d3-8865-5e19d67eccce]
```