### PR TITLE
fix: place prompt after CLI flags in BuildCommandWithPrompt (Issue #111)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ make ci                           # Run full CI pipeline locally
 - **Table-driven tests**: Use for complex scenarios with multiple test cases
 - **Functional options**: `WithXxx()` pattern for configuration
 - **Benchmark tests**: Use `var sink any` to prevent dead code elimination, always call `b.ReportAllocs()` and `b.ResetTimer()`
+- **tool_use_result metadata**: `UserMessage.ToolUseResult` carries rich edit info (filePath, structuredPatch, diffs); check with `HasToolUseResult()` before accessing via `GetToolUseResult()`
 
 <!-- END AUTO-MANAGED -->
 
@@ -111,7 +112,7 @@ make ci                           # Run full CI pipeline locally
 - Conventional commit messages: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`
 - Issue references in commits: `(Issue #N)` or `(#N)`, use `Closes #N` in PR body
 - PR-based workflow with CI checks
-- Recent focus: Comprehensive benchmarking for performance-critical modules (Issue #74, commits e1c48f3, 368fa3e)
+- Recent focus: CLI flag ordering fix - `BuildCommandWithPrompt()` places `--print <prompt>` after all option flags so flags like `--mcp-config` are parsed correctly (Issue #111)
 - Benchmark organization: Table-driven benchmarks across all core modules (options, parser, shared, control, cli)
 - Makefile integration: All code quality checks (fmt, vet, lint, cyclo) unified under `make check`
 

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -16,7 +16,7 @@ examples/
 ├── 02_client_streaming/     # Real-time streaming responses
 ├── 03_client_multi_turn/    # Multi-turn conversations
 ├── 04_query_with_tools/     # File operations with Query API
-├── 05_client_with_tools/    # Interactive file workflows
+├── 05_client_with_tools/    # Interactive file workflows; tool_use_result metadata, SetPermissionMode
 ├── 06_query_with_mcp/       # MCP server integration (Query)
 ├── 07_client_with_mcp/      # MCP server integration (Client)
 ├── 08_client_advanced/      # Error handling, model switching

--- a/internal/cli/CLAUDE.md
+++ b/internal/cli/CLAUDE.md
@@ -20,6 +20,7 @@ cli/
 **Key Functions**:
 - `FindCLI()`: Searches PATH and platform-specific locations for Claude CLI
 - `BuildCommand()`: Constructs CLI arguments from Options
+- `BuildCommandWithPrompt()`: Constructs CLI command for one-shot queries; prompt appended last after all flags so CLI parses flags (e.g. `--mcp-config`) correctly
 - `GetCLIVersion()`: Extracts and validates CLI version
 
 <!-- END AUTO-MANAGED -->

--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -133,12 +133,15 @@ func BuildCommandWithPrompt(cliPath string, options *shared.Options, prompt stri
 	cmd := []string{cliPath}
 
 	// Base arguments - always include these
-	cmd = append(cmd, "--output-format", "stream-json", "--verbose", "--print", prompt)
+	cmd = append(cmd, "--output-format", "stream-json", "--verbose")
 
-	// Add all configuration options as CLI flags
+	// Add all configuration options as CLI flags before the prompt
 	if options != nil {
 		cmd = addOptionsToCommand(cmd, options)
 	}
+
+	// Prompt must be last so the CLI parses all flags (e.g. --mcp-config) correctly
+	cmd = append(cmd, "--print", prompt)
 
 	return cmd
 }

--- a/internal/cli/discovery_test.go
+++ b/internal/cli/discovery_test.go
@@ -190,6 +190,15 @@ func TestBuildCommandWithPrompt(t *testing.T) {
 		{"basic_prompt", &shared.Options{}, "What is 2+2?", validateBasicPromptCommand},
 		{"empty_prompt", nil, "", validateEmptyPromptCommand},
 		{"multiline_prompt", &shared.Options{Model: stringPtr("claude-3-sonnet")}, "Line 1\nLine 2", validateBasicPromptCommand},
+		{
+			"prompt_after_options",
+			&shared.Options{
+				ExtraArgs: map[string]*string{"mcp-config": stringPtr("/tmp/mcp.json")},
+				Model:     stringPtr("claude-3-sonnet"),
+			},
+			"Use get_server_time tool",
+			validatePromptAfterOptions,
+		},
 	}
 
 	for _, test := range tests {
@@ -482,6 +491,35 @@ func validateEmptyPromptCommand(t *testing.T, cmd []string, _ string) {
 	assertContainsArgs(t, cmd, "--output-format", "stream-json")
 	assertContainsArg(t, cmd, "--verbose")
 	assertContainsArgs(t, cmd, "--print", "") // Empty prompt should still be there
+}
+
+func validatePromptAfterOptions(t *testing.T, cmd []string, prompt string) {
+	t.Helper()
+	assertContainsArgs(t, cmd, "--print", prompt)
+	assertContainsArgs(t, cmd, "--mcp-config", "/tmp/mcp.json")
+	assertContainsArgs(t, cmd, "--model", "claude-3-sonnet")
+
+	// --print must come AFTER all option flags so the CLI parses them correctly
+	printIdx := -1
+	mcpIdx := -1
+	modelIdx := -1
+	for i, arg := range cmd {
+		switch arg {
+		case "--print":
+			printIdx = i
+		case "--mcp-config":
+			mcpIdx = i
+		case "--model":
+			modelIdx = i
+		}
+	}
+
+	if mcpIdx > printIdx {
+		t.Errorf("--mcp-config (index %d) must appear before --print (index %d), got %v", mcpIdx, printIdx, cmd)
+	}
+	if modelIdx > printIdx {
+		t.Errorf("--model (index %d) must appear before --print (index %d), got %v", modelIdx, printIdx, cmd)
+	}
 }
 
 // Helper function for string pointers

--- a/internal/parser/CLAUDE.md
+++ b/internal/parser/CLAUDE.md
@@ -33,6 +33,7 @@ parser/
 - Buffer limit: 1MB max (`MaxBufferSize`) to prevent memory exhaustion
 - Speculative parsing: Match Python SDK behavior for streaming JSON
 - Type discrimination: Use `"type"` field to determine message type
+- `tool_use_result` extraction: `parseUserMessage` reads top-level `tool_use_result` map and passes it into `UserMessage.ToolUseResult`
 
 <!-- END AUTO-MANAGED -->
 

--- a/internal/shared/CLAUDE.md
+++ b/internal/shared/CLAUDE.md
@@ -31,6 +31,11 @@ shared/
 - Concrete types: `UserMessage`, `AssistantMessage`, `SystemMessage`, `ResultMessage`
 - Content blocks: `TextBlock`, `ThinkingBlock`, `ToolUseBlock`, `ToolResultBlock`
 
+**UserMessage fields**:
+- `Content`: string or `[]ContentBlock`
+- `UUID`, `ParentToolUseID`: optional string pointers
+- `ToolUseResult map[string]any`: rich edit metadata (filePath, structuredPatch, diffs); use `HasToolUseResult()` / `GetToolUseResult()`
+
 <!-- END AUTO-MANAGED -->
 
 <!-- AUTO-MANAGED: conventions -->


### PR DESCRIPTION
## Summary

`BuildCommandWithPrompt()` placed the prompt positional argument before option flags like `--mcp-config`, causing the Claude CLI to stop parsing flags after the positional arg. This meant MCP servers (and other options) were silently ignored in `Query()` one-shot mode.

Moves `--print <prompt>` to the end of the command so all flags are parsed correctly, matching how `BuildCommand()` already works for streaming mode.

## Changes

### Files Modified
- `internal/cli/discovery.go` - Reorder `BuildCommandWithPrompt()` to append prompt after options
- `internal/cli/discovery_test.go` - Add `prompt_after_options` test case verifying flag ordering

## Test Plan
- [x] New test `prompt_after_options` verifies `--mcp-config` and `--model` appear before `--print`
- [x] All existing `TestBuildCommandWithPrompt` cases still pass
- [x] Full test suite passes with race detector (`go test -race ./...`)
- [x] `go vet` and `go fmt` clean

## TDD Cycle
- RED: Added `prompt_after_options` test asserting flags come before prompt - failed as expected
- GREEN: Moved `--print prompt` append to after `addOptionsToCommand()` - all tests pass

Closes #111