### PR TITLE
fix: handle initialization errors in control protocol (Issue #110)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ make ci                           # Run full CI pipeline locally
 - **Functional options**: `WithXxx()` pattern for configuration
 - **Benchmark tests**: Use `var sink any` to prevent dead code elimination, always call `b.ReportAllocs()` and `b.ResetTimer()`
 - **tool_use_result metadata**: `UserMessage.ToolUseResult` carries rich edit info (filePath, structuredPatch, diffs); check with `HasToolUseResult()` before accessing via `GetToolUseResult()`
+- **Init error routing**: `subprocess.routeInitError()` detects error `ResultMessage` arriving before transport is connected and calls `protocol.HandleControlInitErr()` to unblock `SendControlRequest()` via `initErrChan`
 
 <!-- END AUTO-MANAGED -->
 
@@ -112,7 +113,7 @@ make ci                           # Run full CI pipeline locally
 - Conventional commit messages: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`
 - Issue references in commits: `(Issue #N)` or `(#N)`, use `Closes #N` in PR body
 - PR-based workflow with CI checks
-- Recent focus: CLI flag ordering fix - `BuildCommandWithPrompt()` places `--print <prompt>` after all option flags so flags like `--mcp-config` are parsed correctly (Issue #111)
+- Recent focus: staticcheck SA5011 fix - add `return` after `t.Fatal()` in subtests to prevent nil pointer dereference warnings; CLI flag ordering fix - `BuildCommandWithPrompt()` places `--print <prompt>` after all option flags (Issue #111)
 - Benchmark organization: Table-driven benchmarks across all core modules (options, parser, shared, control, cli)
 - Makefile integration: All code quality checks (fmt, vet, lint, cyclo) unified under `make check`
 
@@ -127,6 +128,7 @@ make ci                           # Run full CI pipeline locally
 - **Thread safety**: All mocks must be thread-safe with proper mutex usage
 - **Self-contained tests**: Each test file has its own helpers to avoid dependencies
 - **Benchmark organization**: Use table-driven benchmarks with realistic scenarios, measure allocations with `b.ReportAllocs()`
+- **t.Fatal() + return**: Always follow `t.Fatal()` with `return` in subtests to prevent staticcheck SA5011 nil pointer dereference warnings (staticcheck does not track that t.Fatal() stops execution)
 
 <!-- END AUTO-MANAGED -->
 

--- a/internal/control/CLAUDE.md
+++ b/internal/control/CLAUDE.md
@@ -41,6 +41,7 @@ control/
 - Thread safety: All state access protected by mutex
 - Timeout handling: Default 60s init timeout, configurable via `WithInitTimeout`
 - Hook registration: `RegisterHook()` returns callback ID for later removal
+- Init error channel: `initErrChan chan error` (buffered, size 1) in Protocol struct; `HandleControlInitErr()` sends non-blocking to unblock `SendControlRequest()` when CLI fails before handshake (e.g., invalid session ID)
 
 <!-- END AUTO-MANAGED -->
 

--- a/internal/control/protocol.go
+++ b/internal/control/protocol.go
@@ -39,6 +39,7 @@ type Protocol struct {
 	// State
 	initialized  bool
 	initResponse *InitializeResponse
+	initErrChan  chan error
 	closed       bool
 	started      bool
 
@@ -112,6 +113,7 @@ func NewProtocol(transport Transport, opts ...ProtocolOption) *Protocol {
 		pendingRequests: make(map[string]chan *Response),
 		messageStream:   make(chan map[string]any, 100),
 		initTimeout:     DefaultInitTimeout,
+		initErrChan:     make(chan error, 1),
 	}
 
 	for _, opt := range opts {
@@ -237,8 +239,21 @@ func (p *Protocol) SendControlRequest(ctx context.Context, request any, timeout 
 		}
 		return response.Response, nil
 
+	case err := <-p.initErrChan:
+		return nil, err
+
 	case <-timeoutCtx.Done():
 		return nil, fmt.Errorf("control request timeout: %w", timeoutCtx.Err())
+	}
+}
+
+// HandleControlInitErr reports an initialization error back to any pending
+// SendControlRequest, unblocking it when the CLI returns an error result
+// instead of a control protocol response (e.g., invalid session ID).
+func (p *Protocol) HandleControlInitErr(err error) {
+	select {
+	case p.initErrChan <- err:
+	default:
 	}
 }
 

--- a/internal/control/protocol_test.go
+++ b/internal/control/protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -762,6 +763,7 @@ func testRouteControlResponse(t *testing.T) {
 	case resp := <-responseChan:
 		if resp == nil {
 			t.Fatal("expected response, got nil")
+			return
 		}
 		assertControlEqual(t, ResponseSubtypeSuccess, resp.Subtype)
 	case <-time.After(1 * time.Second):
@@ -1955,4 +1957,96 @@ func testMarshalRewindFilesRequest(t *testing.T) {
 	}
 	assertControlEqual(t, "rewind_files", request["subtype"])
 	assertControlEqual(t, "msg-uuid-12345", request["user_message_id"])
+}
+
+// =============================================================================
+// Phase 9: HandleControlInitErr Tests (Issue #110)
+// =============================================================================
+
+func TestHandleControlInitErr(t *testing.T) {
+	t.Run("unblocks_send_control_request", testInitErrUnblocksSendControlRequest)
+	t.Run("non_blocking_when_no_receiver", testInitErrNonBlockingNoReceiver)
+	t.Run("only_first_error_delivered", testInitErrOnlyFirstDelivered)
+}
+
+func testInitErrUnblocksSendControlRequest(t *testing.T) {
+	t.Helper()
+
+	ctx, cancel := setupControlTestContext(t, 5*time.Second)
+	defer cancel()
+
+	transport := newControlMockTransport()
+	protocol := NewProtocol(transport)
+
+	err := protocol.Start(ctx)
+	assertControlNoError(t, err)
+	defer func() { _ = protocol.Close() }()
+
+	// Inject an init error after a short delay (simulates early result message)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		protocol.HandleControlInitErr(fmt.Errorf("No conversation found with session ID: abc-123"))
+	}()
+
+	// SendControlRequest should unblock with the init error instead of timing out
+	_, err = protocol.SendControlRequest(ctx, InitializeRequest{
+		Subtype: SubtypeInitialize,
+	}, 2*time.Second)
+
+	if err == nil {
+		t.Fatal("expected error from SendControlRequest")
+	}
+	if !strings.Contains(err.Error(), "No conversation found") {
+		t.Errorf("expected session ID error, got: %v", err)
+	}
+}
+
+func testInitErrNonBlockingNoReceiver(t *testing.T) {
+	t.Helper()
+
+	transport := newControlMockTransport()
+	protocol := NewProtocol(transport)
+
+	// HandleControlInitErr should not block even with no receiver
+	done := make(chan struct{})
+	go func() {
+		protocol.HandleControlInitErr(fmt.Errorf("test error"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Non-blocking - good
+	case <-time.After(1 * time.Second):
+		t.Fatal("HandleControlInitErr blocked without a receiver")
+	}
+}
+
+func testInitErrOnlyFirstDelivered(t *testing.T) {
+	t.Helper()
+
+	transport := newControlMockTransport()
+	protocol := NewProtocol(transport)
+
+	// Send two errors - only the first should be buffered (chan size 1)
+	protocol.HandleControlInitErr(fmt.Errorf("first error"))
+	protocol.HandleControlInitErr(fmt.Errorf("second error"))
+
+	// Drain the channel - should get only the first
+	select {
+	case err := <-protocol.initErrChan:
+		if !strings.Contains(err.Error(), "first error") {
+			t.Errorf("expected first error, got: %v", err)
+		}
+	default:
+		t.Fatal("expected an error in initErrChan")
+	}
+
+	// Channel should be empty now
+	select {
+	case err := <-protocol.initErrChan:
+		t.Errorf("expected empty channel, got: %v", err)
+	default:
+		// Good - empty
+	}
 }

--- a/internal/parser/json.go
+++ b/internal/parser/json.go
@@ -325,6 +325,15 @@ func (p *Parser) parseResultMessage(data map[string]any) (*shared.ResultMessage,
 		result.StructuredOutput = structuredOutput
 	}
 
+	// Parse errors array
+	if errorsRaw, ok := data["errors"].([]any); ok {
+		for _, e := range errorsRaw {
+			if s, ok := e.(string); ok {
+				result.Errors = append(result.Errors, s)
+			}
+		}
+	}
+
 	return result, nil
 }
 

--- a/internal/parser/json_test.go
+++ b/internal/parser/json_test.go
@@ -1190,6 +1190,7 @@ func assertBufferOverflowError(t *testing.T, err error) {
 	jsonDecodeErr := shared.AsJSONDecodeError(err)
 	if jsonDecodeErr == nil {
 		t.Fatalf("Expected JSONDecodeError, got %T", err)
+		return
 	}
 	if !strings.Contains(jsonDecodeErr.Error(), "buffer overflow") {
 		t.Errorf("Expected buffer overflow error, got %q", jsonDecodeErr.Error())
@@ -1765,4 +1766,89 @@ func TestStreamEventErrorConditions(t *testing.T) {
 			assertParseError(t, err, test.expectError)
 		})
 	}
+}
+
+// TestResultMessageErrorsField tests the errors array field on ResultMessage (Issue #110)
+func TestResultMessageErrorsField(t *testing.T) {
+	parser := setupParserTest(t)
+
+	baseData := map[string]any{
+		"type":            "result",
+		"subtype":         "error",
+		"duration_ms":     0.0,
+		"duration_api_ms": 0.0,
+		"is_error":        true,
+		"num_turns":       0.0,
+		"session_id":      "s123",
+	}
+
+	t.Run("with_errors_array", func(t *testing.T) {
+		data := make(map[string]any)
+		for k, v := range baseData {
+			data[k] = v
+		}
+		data["errors"] = []any{
+			"No conversation found with session ID: abc-123",
+			"second error",
+		}
+
+		msg, err := parser.ParseMessage(data)
+		assertNoParseError(t, err)
+
+		resultMsg := msg.(*shared.ResultMessage)
+		if len(resultMsg.Errors) != 2 {
+			t.Fatalf("expected 2 errors, got %d", len(resultMsg.Errors))
+		}
+		if resultMsg.Errors[0] != "No conversation found with session ID: abc-123" {
+			t.Errorf("unexpected first error: %s", resultMsg.Errors[0])
+		}
+		if resultMsg.Errors[1] != "second error" {
+			t.Errorf("unexpected second error: %s", resultMsg.Errors[1])
+		}
+	})
+
+	t.Run("without_errors_array", func(t *testing.T) {
+		msg, err := parser.ParseMessage(baseData)
+		assertNoParseError(t, err)
+
+		resultMsg := msg.(*shared.ResultMessage)
+		if len(resultMsg.Errors) != 0 {
+			t.Errorf("expected empty errors, got %v", resultMsg.Errors)
+		}
+	})
+
+	t.Run("with_empty_errors_array", func(t *testing.T) {
+		data := make(map[string]any)
+		for k, v := range baseData {
+			data[k] = v
+		}
+		data["errors"] = []any{}
+
+		msg, err := parser.ParseMessage(data)
+		assertNoParseError(t, err)
+
+		resultMsg := msg.(*shared.ResultMessage)
+		if len(resultMsg.Errors) != 0 {
+			t.Errorf("expected empty errors, got %v", resultMsg.Errors)
+		}
+	})
+
+	t.Run("with_non_string_errors_ignored", func(t *testing.T) {
+		data := make(map[string]any)
+		for k, v := range baseData {
+			data[k] = v
+		}
+		data["errors"] = []any{"valid error", 123, true}
+
+		msg, err := parser.ParseMessage(data)
+		assertNoParseError(t, err)
+
+		resultMsg := msg.(*shared.ResultMessage)
+		if len(resultMsg.Errors) != 1 {
+			t.Fatalf("expected 1 error (non-strings skipped), got %d", len(resultMsg.Errors))
+		}
+		if resultMsg.Errors[0] != "valid error" {
+			t.Errorf("unexpected error: %s", resultMsg.Errors[0])
+		}
+	})
 }

--- a/internal/shared/errors_helpers_test.go
+++ b/internal/shared/errors_helpers_test.go
@@ -188,6 +188,7 @@ func TestAsErrorHelpersFieldAccess(t *testing.T) {
 		result := AsCLINotFoundError(err)
 		if result == nil {
 			t.Fatal("AsCLINotFoundError returned nil")
+			return
 		}
 		if result.Path != testCLIPath {
 			t.Errorf("Path field: got %q, want %q", result.Path, testCLIPath)
@@ -200,6 +201,7 @@ func TestAsErrorHelpersFieldAccess(t *testing.T) {
 		result := AsProcessError(err)
 		if result == nil {
 			t.Fatal("AsProcessError returned nil")
+			return
 		}
 		if result.ExitCode != exitCode {
 			t.Errorf("ExitCode field: got %d, want %d", result.ExitCode, exitCode)
@@ -217,6 +219,7 @@ func TestAsErrorHelpersFieldAccess(t *testing.T) {
 		result := AsJSONDecodeError(err)
 		if result == nil {
 			t.Fatal("AsJSONDecodeError returned nil")
+			return
 		}
 		if result.Line != line {
 			t.Errorf("Line field: got %q, want %q", result.Line, line)
@@ -235,6 +238,7 @@ func TestAsErrorHelpersFieldAccess(t *testing.T) {
 		result := AsMessageParseError(err)
 		if result == nil {
 			t.Fatal("AsMessageParseError returned nil")
+			return
 		}
 		dataMap, ok := result.Data.(map[string]any)
 		if !ok {
@@ -255,6 +259,7 @@ func TestAsErrorHelpersFieldAccess(t *testing.T) {
 		result := AsCLINotFoundError(doubleWrapped)
 		if result == nil {
 			t.Fatal("AsCLINotFoundError returned nil for double-wrapped error")
+			return
 		}
 		if result.Path != path {
 			t.Errorf("Path field through double wrapping: got %q, want %q", result.Path, path)

--- a/internal/shared/message.go
+++ b/internal/shared/message.go
@@ -177,6 +177,7 @@ type ResultMessage struct {
 	DurationMs       int             `json:"duration_ms"`
 	DurationAPIMs    int             `json:"duration_api_ms"`
 	IsError          bool            `json:"is_error"`
+	Errors           []string        `json:"errors,omitempty"`
 	NumTurns         int             `json:"num_turns"`
 	SessionID        string          `json:"session_id"`
 	TotalCostUSD     *float64        `json:"total_cost_usd,omitempty"`

--- a/internal/subprocess/CLAUDE.md
+++ b/internal/subprocess/CLAUDE.md
@@ -40,6 +40,7 @@ subprocess/
 - Message routing: Distinguish control vs regular messages by type
 - Protocol adapter: Bridges subprocess stdin to `control.Transport` interface
 - Resource cleanup: Always close stdin before waiting for process exit
+- Init error routing: `routeInitError()` in io.go detects error `ResultMessage` before `t.connected` is set and calls `protocol.HandleControlInitErr()`; `formatInitError()` builds error string with priority: `Errors` slice > `Result` field > `Subtype` fallback
 
 <!-- END AUTO-MANAGED -->
 

--- a/internal/subprocess/io.go
+++ b/internal/subprocess/io.go
@@ -55,6 +55,11 @@ func (t *Transport) handleStdout() {
 				continue
 			}
 
+			// If this is an error ResultMessage before we're fully connected,
+			// it means the CLI failed during init (e.g., invalid session ID).
+			// Route the error to the control protocol to unblock Initialize().
+			t.routeInitError(msg)
+
 			// Check if this is a control message that should be routed to the protocol
 			if rawCtrl, ok := msg.(*shared.RawControlMessage); ok {
 				// Route control messages to the protocol for request/response correlation
@@ -119,6 +124,29 @@ func (t *Transport) handleStderrCallback() {
 		}()
 	}
 	// Silently ignore scanner errors (matches Python SDK's except Exception: pass)
+}
+
+// routeInitError checks if a message is an error ResultMessage arriving before
+// the transport is fully connected, and routes it to the control protocol to
+// unblock Initialize().
+func (t *Transport) routeInitError(msg shared.Message) {
+	resultMsg, ok := msg.(*shared.ResultMessage)
+	if !ok || t.connected || !resultMsg.IsError || t.protocol == nil {
+		return
+	}
+	t.protocol.HandleControlInitErr(fmt.Errorf("%s", formatInitError(resultMsg)))
+}
+
+// formatInitError builds a meaningful error string from a ResultMessage that
+// arrived during initialization. Prefers Errors, falls back to Result, then Subtype.
+func formatInitError(msg *shared.ResultMessage) string {
+	if len(msg.Errors) > 0 {
+		return strings.Join(msg.Errors, "; ")
+	}
+	if msg.Result != nil && *msg.Result != "" {
+		return *msg.Result
+	}
+	return fmt.Sprintf("initialization failed with subtype: %s", msg.Subtype)
 }
 
 // setupStderr configures stderr handling based on options.

--- a/internal/subprocess/io_test.go
+++ b/internal/subprocess/io_test.go
@@ -11,6 +11,77 @@ import (
 	"github.com/severity1/claude-agent-sdk-go/internal/shared"
 )
 
+// TestFormatInitError tests the error message formatting for early init failures (Issue #110)
+func TestFormatInitError(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      *shared.ResultMessage
+		expected string
+	}{
+		{
+			name: "uses_errors_field",
+			msg: &shared.ResultMessage{
+				IsError: true,
+				Errors:  []string{"No conversation found with session ID: abc-123"},
+				Subtype: "error",
+			},
+			expected: "No conversation found with session ID: abc-123",
+		},
+		{
+			name: "joins_multiple_errors",
+			msg: &shared.ResultMessage{
+				IsError: true,
+				Errors:  []string{"error one", "error two"},
+				Subtype: "error",
+			},
+			expected: "error one; error two",
+		},
+		{
+			name: "falls_back_to_result",
+			msg: &shared.ResultMessage{
+				IsError: true,
+				Errors:  nil,
+				Result:  strPtr("something went wrong"),
+				Subtype: "error",
+			},
+			expected: "something went wrong",
+		},
+		{
+			name: "falls_back_to_subtype",
+			msg: &shared.ResultMessage{
+				IsError: true,
+				Errors:  nil,
+				Result:  nil,
+				Subtype: "fatal",
+			},
+			expected: "initialization failed with subtype: fatal",
+		},
+		{
+			name: "empty_errors_falls_back_to_result",
+			msg: &shared.ResultMessage{
+				IsError: true,
+				Errors:  []string{},
+				Result:  strPtr("fallback message"),
+				Subtype: "error",
+			},
+			expected: "fallback message",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatInitError(tc.msg)
+			if got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
 // TestTransportHandleStdoutErrorPaths tests uncovered handleStdout scenarios
 func TestTransportHandleStdoutErrorPaths(t *testing.T) {
 	ctx, cancel := setupTransportTestContext(t, 5*time.Second)

--- a/internal/subprocess/transport_test.go
+++ b/internal/subprocess/transport_test.go
@@ -499,6 +499,7 @@ func TestNewWithPrompt(t *testing.T) {
 
 			if transport == nil {
 				t.Fatal("Expected transport to be created, got nil")
+				return
 			}
 
 			// Verify key configuration


### PR DESCRIPTION
## Summary

- When Claude CLI returns an error `result` message during control protocol initialization (e.g., invalid session ID), `SendControlRequest` now unblocks via `initErrChan` instead of hanging until timeout
- Adds `Errors []string` field to `ResultMessage` with manual parsing (no marshal/unmarshal round-trip)
- Extracts `routeInitError()` in subprocess io.go to keep `handleStdout` complexity unchanged
- Fixes all pre-existing staticcheck SA5011 nil pointer warnings across test files

Based on the work started in #110 by @Ccheers. This PR reimplements the fix with proper field parsing (avoiding the json.Marshal/Unmarshal round-trip that broke `TestResultMessageOptionalFields`), adds comprehensive tests, and includes error message fallback logic.

## Test plan

- [x] `TestHandleControlInitErr` - verifies initErrChan unblocks SendControlRequest, non-blocking behavior, and single-delivery semantics
- [x] `TestResultMessageErrorsField` - verifies parsing with errors array, empty array, missing field, and non-string elements
- [x] `TestFormatInitError` - verifies error message priority: Errors > Result > Subtype fallback
- [x] Full test suite passes with race detector (`go test -race ./...`)
- [x] `golangci-lint run` reports 0 issues

Closes #110