### PR TITLE
docs: add Python SDK PR replay tracker and update TDD/qualify commands

### DIFF
--- a/.claude/commands/qualify.md
+++ b/.claude/commands/qualify.md
@@ -1,0 +1,161 @@
+---
+argument-hint: <issue-or-pr-number>
+description: Qualify an open issue or PR against requirements and Python SDK parity before /tdd
+---
+
+# Issue and PR Qualification
+
+Validate issue/PR #$ARGUMENTS for correctness, completeness, and Python SDK alignment. Produces a verdict report that feeds into `/tdd`.
+
+## Phase 1: Identification & Context Gathering
+
+Determine what #$ARGUMENTS is and find its linked counterpart:
+
+1. **Check if it is an issue** - Run `gh issue view $ARGUMENTS --json number,title,body,state,labels,comments`
+2. **Check if it is a PR** - Run `gh pr view $ARGUMENTS --json number,title,body,state,files,additions,deletions,commits,comments,headRefName`
+3. **Find the linked counterpart:**
+   - If PR: extract linked issue from body (`Closes #N`, `Fixes #N`, `Issue #N`, `(Issue #N)`) and fetch it
+   - If issue: search for linked PRs via `gh pr list --search "issue #$ARGUMENTS"` and check open PRs referencing it
+4. **Fetch all comments** on both the issue and PR (if both exist) for additional context
+
+Display a summary:
+
+```
+Context for #$ARGUMENTS
+-----------------------
+Issue: #<number> - <title> (<state>)
+PR:    #<number> - <title> (<state>) [or "None found"]
+```
+
+---
+
+## Phase 2: Issue Validation
+
+Assess whether the issue is well-defined and ready for implementation:
+
+1. **Check issue structure** - Does the body contain:
+   - [ ] Clear description of the problem or feature
+   - [ ] Reproduction steps (for bugs)
+   - [ ] Proposed Implementation section
+   - [ ] Files to Modify section
+   - [ ] Example Usage (if applicable)
+2. **Read all comments** - Look for scope changes, decisions, or additional requirements added after filing
+3. **Check labels** - Confirm categorization (bug, enhancement, good first issue, etc.)
+4. **Extract requirements** - Build a numbered list of acceptance criteria from the issue body and comments. Include both explicit requirements and implied ones.
+
+Output the requirements list - this feeds directly into `/tdd` Phase 2:
+
+```
+Requirements for #$ARGUMENTS
+-----------------------------
+1. <requirement>
+2. <requirement>
+...
+```
+
+**If the issue is missing critical information:** Note the gaps but continue - the verdict will reflect them.
+
+---
+
+## Phase 3: Python SDK Cross-Reference
+
+Determine if this change has a Python SDK equivalent and validate alignment:
+
+1. **Fetch official Python SDK docs:**
+   ```bash
+   curl -s https://platform.claude.com/docs/en/agent-sdk/python.md
+   ```
+2. **Search local Python SDK clone** (if `../claude-agent-sdk-python/` exists):
+   - First run `git -C ../claude-agent-sdk-python pull origin main` to ensure latest changes are available
+   - Check `docs/tracking/README.md` to see if this issue maps to a known Python SDK PR. If a tracker entry exists, use the Python PR number for precise cross-referencing.
+   - Look for matching function/method names, types, or behavior
+   - Check git log for related commits or fixes
+3. **Follow referenced PRs** - If the issue body references `anthropics/claude-agent-sdk-python#NNN`, fetch that PR for context
+4. **Check Python SDK issue tracker** - Search for related issues via `gh issue list -R anthropics/claude-agent-sdk-python --search "<keywords>"`
+
+**Classify the change:**
+
+- `PARITY_REQUIRED` - Python SDK has this feature/fix; Go must match the behavior
+- `GO_SPECIFIC` - Legitimate Go-only concern (e.g., context handling, functional options, goroutine safety)
+- `AHEAD_OF_PYTHON` - Feature the Python SDK does not have yet; flag for discussion
+
+If `PARITY_REQUIRED`: document the expected behavior from the Python SDK, including API signatures, edge case handling, and any Go-specific adaptations needed. This feeds into `/tdd` Phase 3.
+
+If Python SDK reference is unavailable (no local clone, docs fetch fails): note this in the verdict and proceed with what is available.
+
+---
+
+## Phase 4: Implementation Review
+
+**If no PR exists, skip to Phase 5.**
+
+When a PR is linked, review the implementation against the requirements:
+
+1. **Fetch the diff** - `gh pr diff <pr-number>`
+2. **Map requirements to diff** - For each requirement from Phase 2, check if the diff addresses it
+3. **Check project conventions:**
+   - [ ] Commits follow conventional prefixes (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`)
+   - [ ] Idiomatic Go patterns (error wrapping with `%w`, context-first, functional options)
+   - [ ] Tests present (table-driven, `t.Helper()` in helpers, thread-safe mocks)
+   - [ ] No unnecessary exports
+   - [ ] Cyclomatic complexity reasonable (threshold: 15)
+   - [ ] Error handling follows project patterns
+4. **Parity verification** (if `PARITY_REQUIRED`):
+   - Compare Go implementation against the Python SDK behavior documented in Phase 3
+   - Verify API surface, semantics, and edge cases match
+   - Flag any behavioral divergence
+5. **Check for common issues:**
+   - Missing error paths
+   - Resource leaks or missing cleanup
+   - Missing context cancellation support
+   - Unrelated changes bundled in
+
+---
+
+## Phase 5: Qualification Verdict
+
+Produce a structured verdict. This report is designed to feed into `/tdd`:
+
+```
+Qualification Verdict: [QUALIFIED | QUALIFIED WITH ITEMS | NOT QUALIFIED]
+
+Subject:
+  Issue: #<number> - <title> (<state>)
+  PR:    #<number> - <title> (<state>) [or "None"]
+
+Requirements:
+  1. <requirement> - [CLEAR | UNCLEAR | MISSING DETAIL]
+  2. <requirement> - [CLEAR | UNCLEAR | MISSING DETAIL]
+
+Python SDK Parity: [PARITY_REQUIRED | GO_SPECIFIC | AHEAD_OF_PYTHON]
+  <reference details - SDK behavior, docs link, or referenced PR>
+
+Implementation Review: [REVIEWED | NO PR | SKIPPED]
+  <if reviewed, per-requirement coverage>
+  1. <requirement> - [MET | PARTIALLY MET | NOT MET]
+  2. <requirement> - [MET | PARTIALLY MET | NOT MET]
+
+Action Items:
+  [must-fix] <specific item>
+  [should-fix] <specific item>
+
+Recommendation:
+  - QUALIFIED: "Ready for /tdd #$ARGUMENTS"
+  - QUALIFIED WITH ITEMS: "Address items above, then /tdd #$ARGUMENTS"
+  - NOT QUALIFIED: "<specific reason and suggested next step>"
+```
+
+**Verdict criteria:**
+
+- `QUALIFIED` - Issue is valid, well-scoped, requirements are clear, parity is understood. Ready for `/tdd`.
+- `QUALIFIED WITH ITEMS` - Mostly ready but has specific items to address first. List each with `must-fix` or `should-fix`.
+- `NOT QUALIFIED` - Significant gaps: unclear requirements, invalid premise, parity conflict, or the issue needs rethinking.
+
+---
+
+## Error Recovery
+
+- **Invalid number:** Report that #$ARGUMENTS was not found as an issue or PR
+- **`gh` not authenticated:** Report and suggest `gh auth login`
+- **Python SDK unavailable:** Proceed with qualification but note parity could not be fully verified
+- **No linked issue or PR:** Proceed with what is available; note the gap in the verdict

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -16,7 +16,8 @@ Verify the development environment is ready:
 3. **Pull latest changes** - Run `git pull` to sync with remote
 4. **Check for existing PRs** - Search for open PRs linked to issue #$ARGUMENTS to avoid duplicate work
 5. **Verify Go environment** - Run `go version` and ensure toolchain is available
-6. **Check for blocking dependencies** - Read issue body and look for "Depends on" or "Blocked by" sections
+6. **Sync Python SDK** - Run `git -C ../claude-agent-sdk-python pull origin main` to ensure local Python SDK reference is current
+7. **Check for blocking dependencies** - Read issue body and look for "Depends on" or "Blocked by" sections
 
 **STOP and report to user if any check fails** - Don't proceed until issues are resolved.
 
@@ -47,9 +48,10 @@ Understand existing patterns to match the project's conventions:
 
 1. **Review Python SDK Reference:**
    - **Fetch official documentation** using `curl -s https://platform.claude.com/docs/en/agent-sdk/python.md` - this is the authoritative Python SDK API reference
-   - Locate corresponding implementation in `../claude-code-sdk-python/` (local clone if available)
+   - Locate corresponding implementation in `../claude-agent-sdk-python/` (local clone)
    - Understand the behavior that needs 100% parity
    - Note any Go-specific adaptations needed
+   - **Check parity tracker** - Read `docs/tracking/README.md` to find if this issue maps to a tracked Python SDK PR. If a tracker entry exists, use the Python PR number as the authoritative reference and read the corresponding Python source changes for exact behavior to replicate.
 
 2. **Discover Existing Patterns:**
    - Search for similar implementations in the codebase
@@ -213,6 +215,7 @@ Verify:
 2. **Reference official docs** - `curl -s https://platform.claude.com/docs/en/agent-sdk/python.md` for API signatures and behavior
 3. **Verify 100% parity** on all implemented features
 4. **Document any intentional deviations** (Go-specific adaptations)
+5. **Update parity tracker** - If this issue corresponds to a tracked Python PR in `docs/tracking/README.md`, update the entry: set Go Status to `done` and fill in the Go PR number
 
 ### Test Authenticity Verification
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ go.work.sum
 
 # Claude Code auto-memory
 .claude/auto-memory/dirty-files
+.claude/auto-memory/dirty-files-*
 
 # Auto-generated fuzz corpus
 testdata/fuzz/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ make ci                           # Run full CI pipeline locally
 - Recent focus: CLI flag ordering fix - `BuildCommandWithPrompt()` places `--print <prompt>` after all option flags so flags like `--mcp-config` are parsed correctly (Issue #111)
 - Benchmark organization: Table-driven benchmarks across all core modules (options, parser, shared, control, cli)
 - Makefile integration: All code quality checks (fmt, vet, lint, cyclo) unified under `make check`
-- Python SDK parity tracking: `docs/tracking/README.md` tracks all Python SDK PRs to port; organized into 7 waves (type safety, hooks, sessions, agent/options, MCP, client methods, bug fixes); last ported feature was tool_use_result (Go PR #99)
+- Python SDK parity tracking: `docs/tracking/README.md` tracks all Python SDK PRs to port; organized into 4 chronological phases (Phase 1: Jan 26-Feb 20, Phase 2: Mar 3-Mar 16, Phase 3: Mar 20-Mar 30, Phase 4: Mar 31-Apr 8); 49 actionable PRs pending; last ported feature was tool_use_result (Go PR #99)
 
 <!-- END AUTO-MANAGED -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,9 @@ make ci                           # Run full CI pipeline locally
 │   ├── shared/            # Shared types (Message, ContentBlock interfaces)
 │   └── subprocess/        # Subprocess management and protocol adapter
 ├── examples/              # Usage examples (numbered by complexity)
-└── docs/architecture/     # Detailed architecture documentation
+└── docs/
+    ├── architecture/      # Detailed architecture documentation
+    └── tracking/          # Python SDK parity tracking (PR replay tracker)
 ```
 
 **Data Flow**:
@@ -115,6 +117,7 @@ make ci                           # Run full CI pipeline locally
 - Recent focus: CLI flag ordering fix - `BuildCommandWithPrompt()` places `--print <prompt>` after all option flags so flags like `--mcp-config` are parsed correctly (Issue #111)
 - Benchmark organization: Table-driven benchmarks across all core modules (options, parser, shared, control, cli)
 - Makefile integration: All code quality checks (fmt, vet, lint, cyclo) unified under `make check`
+- Python SDK parity tracking: `docs/tracking/README.md` tracks all Python SDK PRs to port; organized into 7 waves (type safety, hooks, sessions, agent/options, MCP, client methods, bug fixes); last ported feature was tool_use_result (Go PR #99)
 
 <!-- END AUTO-MANAGED -->
 

--- a/docs/tracking/README.md
+++ b/docs/tracking/README.md
@@ -1,0 +1,205 @@
+# Python SDK PR Replay Tracker
+
+Tracks all Python SDK PRs that need to be replayed into the Go SDK to restore parity.
+
+## Snapshot
+
+| Field | Value |
+|:------|:------|
+| Snapshot date | April 12, 2026 |
+| Coverage window | Jan 6, 2026 - April 12, 2026 |
+| Parity milestone | Go PR #77 (Jan 6, 2026) - formal parity documentation |
+| Last ported feature | Go PR #99 (Jan 24, 2026) - tool_use_result (Python PR #495) |
+| Python SDK at checkpoint | v0.1.22 |
+| Python SDK at snapshot | v0.1.58 |
+
+PRs merged after April 12, 2026 are NOT tracked here. Add them manually and update the snapshot date.
+
+## Summary
+
+| Priority | Count | Description |
+|:---------|:------|:------------|
+| P0 | 8 | Message types/parsing - broken deserialization if missing |
+| P1 | 25 | New client methods, options, control protocol features |
+| P2 | 15 | Bug fixes - evaluate Go applicability |
+| Skip | 16+ | CI/CD, Python typing, async-specific, PyPI/wheel, CLI bumps |
+| **Actionable** | **48** | |
+
+## Priority Scale
+
+- **P0 (Critical):** New fields or types on messages. Missing these means the Go SDK silently drops data from CLI responses or fails to deserialize. Must be done first.
+- **P1 (High):** New client methods, configuration options, or control protocol features. The SDK works without these but lacks functionality the Python SDK offers.
+- **P2 (Medium):** Bug fixes from the Python SDK. Each must be evaluated against the Go codebase - some may already be handled differently, some may need porting.
+- **Skip:** Not applicable to Go SDK. CI/CD workflows, Python-specific typing (typing_extensions, TypedDict compat, Annotated), Python async-specific fixes (cancel scope, event loop), PyPI/wheel publishing, CLI version bumps, docs-only changes.
+
+## Implementation Waves
+
+### Wave 1 - Type Safety (P0)
+
+PRs: #506, #598, #619, #621, #648, #685, #718, #749
+
+Scope: Add missing fields to ResultMessage (stop_reason, errors), AssistantMessage (usage, error fix, dropped fields). Add RateLimitEvent message type. Add typed TaskStarted/TaskProgress/TaskNotification subtypes. Handle unknown message types gracefully.
+
+Go files: `internal/shared/message.go`, `internal/parser/parser.go`
+
+### Wave 2 - Hook System
+
+PRs: #535, #545, #628
+
+Scope: Add PostToolUseFailure hook event. Add Notification, SubagentStart, PermissionRequest hook events. Add agent_id/agent_type fields to tool-lifecycle hook inputs.
+
+Go files: `internal/control/types_hook.go`, `internal/control/hooks.go`
+
+### Wave 3 - Session Management
+
+PRs: #622, #667, #668, #670, #744, #750
+
+Scope: Add list_sessions(), get_session_info(), get_session_messages(), rename_session(), tag_session(), fork_session(), delete_session() functions. Add offset pagination. Add session_id option. Add tag/created_at to SDKSessionInfo.
+
+Go files: `client.go`, `options.go`, `internal/control/`
+
+### Wave 4 - Agent/Options
+
+PRs: #468, #565, #591, #684, #747, #759, #782, #785, #796, #797
+
+Scope: Send agent definitions via initialize request (not CLI flag). Add ThinkingConfig types + effort option. Add SystemPromptFile support. Expand AgentDefinition with skills, memory, mcpServers, disallowedTools, maxTurns, initialPrompt, background, effort, permissionMode. Add task_budget option. Add 'auto' PermissionMode. Fix --thinking flag construction. Add exclude_dynamic_sections on SystemPromptPreset.
+
+Go files: `internal/shared/options.go`, `options.go`, `internal/cli/command.go`
+
+### Wave 5 - MCP Enhancements
+
+PRs: #516, #551, #620
+
+Scope: Add get_mcp_status() method. Add MCP tool annotations. Add reconnect_mcp_server() and toggle_mcp_server() methods with typed McpServerStatus.
+
+Go files: `mcp.go`, `client.go`, `internal/control/`
+
+### Wave 6 - New Client Methods
+
+PRs: #751, #754, #764
+
+Scope: Handle control_cancel_request from CLI. Add tool_use_id/agent_id to ToolPermissionContext. Add get_context_usage() method.
+
+Go files: `client.go`, `internal/control/types.go`, `transport.go`
+
+### Wave 7 - Bug Fix Audit
+
+PRs: #630, #686, #717, #719, #720, #723, #725, #729, #731, #732, #743, #756, #769, #778, #780
+
+Scope: Evaluate each fix against Go codebase. Key items: dontAsk permission mode (#719), skip non-JSON stdout lines (#723), SIGKILL fallback (#729), filter CLAUDECODE env var (#732), string prompt fixes (#769, #780).
+
+Go files: various - each fix evaluated independently
+
+---
+
+## Tracking Table
+
+### Already Ported
+
+| Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
+|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
+| #495 | tool_use_result on UserMessage | Jan 23 | feat | - | - | done | #99 | Added ToolUseResult map[string]any field to UserMessage with HasToolUseResult()/GetToolUseResult() helpers |
+
+### P0 - Critical
+
+| Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
+|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
+| #506 | Properly populate AssistantMessage error field | Feb 3 | fix | P0 | 1 | pending | - | Python fixed AssistantMessage.error not being populated from JSON during deserialization. Go SDK has AssistantMessage.Error *AssistantMessageError - verify UnmarshalJSON in `internal/shared/message.go` correctly parses the `error` object with type/message fields. Test with rate_limit, billing_error, server_error payloads. |
+| #598 | Handle unknown message types gracefully | Feb 20 | fix | P0 | 1 | pending | - | Python returns a raw/passthrough message instead of crashing on unrecognized `type` field. Go SDK parser in `internal/parser/parser.go` likely returns error on unknown types. Change to return RawMessage or fallback type so new CLI message types don't break existing consumers. Forward-compatibility. |
+| #619 | stop_reason on ResultMessage | Mar 3 | feat | P0 | 1 | pending | - | Python added `stop_reason: str` to ResultMessage (values: "end_turn", "max_tokens", "stop_sequence"). Add `StopReason string` field with `json:"stop_reason"` to ResultMessage in `internal/shared/message.go`. Wire through UnmarshalJSON. |
+| #621 | Typed TaskStarted/TaskProgress/TaskNotification | Mar 3 | feat | P0 | 1 | pending | - | Python created typed SystemMessage subclasses: TaskStartedMessage (task_id, prompt), TaskProgressMessage (task_id, tool_name, progress), TaskNotificationMessage (task_id, status, usage). Go SDK uses generic SystemMessage with Data map. Add concrete structs for each subtype, parse on SystemMessage.Subtype in `internal/shared/message.go`. Add TaskUsage struct (total_tokens, tool_uses, duration_ms). TaskNotificationStatus enum: "completed", "failed", "stopped". |
+| #648 | Typed RateLimitEvent message | Mar 12 | feat | P0 | 1 | pending | - | Python added dedicated RateLimitEvent message type (not SystemMessage) with RateLimitInfo: status, resets_at, rate_limit_type, utilization, overage_status, overage_resets_at, overage_disabled_reason, raw. Add RateLimitEvent struct implementing Message interface, RateLimitInfo struct, parser update to recognize type "rate_limit" in `internal/parser/parser.go`. Also carries uuid and session_id. |
+| #685 | Preserve per-turn usage on AssistantMessage | Mar 16 | feat | P0 | 1 | pending | - | Python added `usage: dict` to AssistantMessage for per-turn token stats (input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens). Add `Usage map[string]any` with `json:"usage,omitempty"` to AssistantMessage in `internal/shared/message.go`. |
+| #718 | Preserve dropped fields on AssistantMessage/ResultMessage | Mar 25 | feat | P0 | 1 | pending | - | Python captures unknown JSON fields into `extra_fields: dict` catch-all to prevent data loss when CLI adds new fields. Add `ExtraFields map[string]any` to AssistantMessage and ResultMessage, populated during UnmarshalJSON by collecting keys not in known fields. Forward-compatibility pattern. |
+| #749 | errors field on ResultMessage | Mar 27 | fix | P0 | 1 | pending | - | Python added `errors: list[str]` to ResultMessage for non-fatal session errors. Add `Errors []string` with `json:"errors,omitempty"` to ResultMessage. Distinct from IsError (fatal failure flag). |
+
+### P1 - High
+
+| Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
+|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
+| #516 | get_mcp_status() method | Jan 26 | feat | P1 | 5 | pending | - | Python added get_mcp_status() returning McpStatusResponse with list of McpServerStatus (name, status, serverInfo, error, config, scope, tools). Add GetMcpStatus(ctx) to Client interface, control request subtype "get_mcp_status", McpServerStatus/McpStatusResponse types in `internal/control/types.go`, wire through Transport. |
+| #535 | PostToolUseFailure hook event | Jan 30 | feat | P1 | 2 | pending | - | Python added "PostToolUseFailure" hook event firing when tool execution fails (distinct from PostToolUse on success). Add `HookEventPostToolUseFailure = "PostToolUseFailure"` constant, PostToolUseFailureHookInput (embeds BaseHookInput, has ToolName, ToolInput, Error), PostToolUseFailureHookSpecificOutput in `internal/control/types_hook.go`. |
+| #545 | Missing hook events + fix fields | Feb 3 | feat | P1 | 2 | pending | - | Python added 3 hook events: "Notification" (system notifications), "SubagentStart" (subagent spawned), "PermissionRequest" (permission requested). Each has HookInput type. Also fixed existing hook fields. Add 3 HookEvent constants, 3 HookInput structs, 3 HookSpecificOutput structs in `internal/control/types_hook.go`. Add SubagentContextMixin equivalent (AgentID, AgentType *string) to relevant inputs. |
+| #551 | MCP tool annotations | Feb 5 | feat | P1 | 5 | pending | - | Python added McpToolAnnotations (readOnly, destructive, openWorld bools) and McpToolInfo (name, description, annotations). Returned in MCP server status and tool listings. Add structs in `mcp.go` or `internal/shared/options.go`. Wire into McpServerStatus.Tools. |
+| #468 | Send agent definitions via initialize request | Feb 5 | feat | P1 | 4 | pending | - | Python sends agents in initialize control request instead of --agents CLI flag. Add `Agents map[string]AgentDefinition` to InitializeRequest in `internal/control/types.go`. Update `internal/control/protocol.go` to include agents. Remove/deprecate --agents flag in `internal/cli/`. |
+| #565 | ThinkingConfig types and effort option | Feb 11 | feat | P1 | 4 | pending | - | Python replaced max_thinking_tokens with ThinkingConfig union: ThinkingConfigAdaptive (type="adaptive"), ThinkingConfigEnabled (type="enabled", budget_tokens), ThinkingConfigDisabled (type="disabled"). Added effort option ("low"/"medium"/"high"/"max"). Add ThinkingConfig interface + 3 structs, WithThinking(), WithEffort() in `options.go`. Update CLI flags: adaptive -> `--thinking adaptive`, disabled -> `--thinking disabled`, enabled -> `--thinking-budget N`. Deprecate WithMaxThinkingTokens(). |
+| #622 | list_sessions / get_session_messages | Mar 3 | feat | P1 | 3 | pending | - | Python added top-level list_sessions() and get_session_messages(session_id) using CLI flags --list-sessions and --get-session-messages. Returns []SDKSessionInfo and []SessionMessage. Add package-level functions, SDKSessionInfo struct (session_id, summary, last_modified, file_size, custom_title, first_prompt, git_branch, cwd), SessionMessage struct (type, uuid, session_id, message, parent_tool_use_id). Standalone CLI invocations, not control protocol. |
+| #628 | agent_id/agent_type in hook inputs | Mar 3 | feat | P1 | 2 | pending | - | Python added optional agent_id and agent_type to PreToolUseHookInput and PostToolUseHookInput via _SubagentContextMixin. Identifies which agent triggered tool use. Add `AgentID *string` and `AgentType *string` to both hook input structs in `internal/control/types_hook.go`. |
+| #648 | Typed RateLimitEvent message | Mar 12 | feat | P0 | 1 | pending | - | (tracked in P0 section above) |
+| #668 | rename_session | Mar 12 | feat | P1 | 3 | pending | - | Python added rename_session(session_id, new_name) to rename a session's custom title. Add RenameSession(ctx, sessionID, newName string) package-level function. Uses CLI flag or control request. |
+| #670 | tag_session with Unicode sanitization | Mar 12 | feat | P1 | 3 | pending | - | Python added tag_session(session_id, tag) with Unicode sanitization (strips non-printable chars, validates length). Add TagSession(ctx, sessionID, tag string) package-level function with equivalent Unicode validation. |
+| #684 | skills/memory/mcpServers on AgentDefinition | Mar 16 | feat | P1 | 4 | pending | - | Python added skills (list), memory (config), mcpServers (map) to AgentDefinition. Add `Skills []any`, `Memory any`, `McpServers map[string]McpServerConfig` with JSON tags to AgentDefinition in `internal/shared/options.go`. |
+| #667 | tag/created_at on SDKSessionInfo + get_session_info | Mar 20 | feat | P1 | 3 | pending | - | Python added tag and created_at fields to SDKSessionInfo. Added get_session_info(session_id) function. Add `Tag *string`, `CreatedAt *string` to SDKSessionInfo. Add GetSessionInfo(ctx, sessionID) package-level function. |
+| #591 | SystemPromptFile support | Mar 25 | feat | P1 | 4 | pending | - | Python added SystemPromptFile TypedDict passing --system-prompt-file to CLI. Add SystemPromptFile struct (Path string), update system_prompt option handling, add --system-prompt-file flag in `internal/cli/command.go`. |
+| #744 | fork_session, delete_session, offset pagination | Mar 26 | feat | P1 | 3 | pending | - | Python added fork_session(session_id) -> ForkSessionResult (new_session_id), delete_session(session_id), offset/limit params on list_sessions(). Add ForkSession(), DeleteSession() functions, ForkSessionResult struct, update ListSessions with pagination. |
+| #747 | task_budget option | Mar 26 | feat | P1 | 4 | pending | - | Python added TaskBudget TypedDict (total int) and task_budget option. Passed as --task-budget CLI flag. Add TaskBudget struct, WithTaskBudget() in `options.go`, CLI flag in `internal/cli/`. |
+| #759 | disallowedTools/maxTurns/initialPrompt on AgentDefinition | Mar 27 | feat | P1 | 4 | pending | - | Python added disallowedTools ([]string), maxTurns (int), initialPrompt (string) to AgentDefinition. Add `DisallowedTools []string`, `MaxTurns *int`, `InitialPrompt *string` with JSON tags to AgentDefinition. |
+| #750 | session_id on ClaudeAgentOptions | Mar 28 | feat | P1 | 3 | pending | - | Python added session_id option for custom session IDs. Passed as --session-id CLI flag. Add WithSessionID(id string) option, `SessionID *string` to Options, CLI flag in `internal/cli/`. |
+| #751 | control_cancel_request handling | Mar 28 | feat | P1 | 6 | pending | - | Python handles control_cancel_request from CLI to cancel pending control requests (e.g., timed-out permission callbacks). Update `internal/control/protocol.go` to handle incoming "cancel_request" by canceling context of pending request by request_id. |
+| #754 | tool_use_id/agent_id in ToolPermissionContext | Mar 28 | feat | P1 | 6 | pending | - | Python added tool_use_id and agent_id to ToolPermissionContext for richer permission callback context. Add `ToolUseID string` and `AgentID string` to ToolPermissionContext in `internal/control/types.go`. |
+| #764 | get_context_usage() | Mar 28 | feat | P1 | 6 | pending | - | Python added get_context_usage() returning ContextUsageResponse: categories ([]ContextUsageCategory with name/tokens/color/isDeferred), totalTokens, maxTokens, percentage, model, optional autoCompactThreshold/mcpTools/agents. Add GetContextUsage(ctx) to Client, ContextUsageResponse/ContextUsageCategory structs, control request subtype, wire through Transport. |
+| #782 | background/effort/permissionMode on AgentDefinition | Mar 31 | feat | P1 | 4 | pending | - | Python added background (bool), effort (string), permissionMode (PermissionMode) to AgentDefinition. Add `Background *bool`, `Effort *string`, `PermissionMode *PermissionMode` with JSON tags. |
+| #785 | 'auto' PermissionMode | Apr 7 | feat | P1 | 4 | pending | - | Python added "auto" PermissionMode (auto-approves safe tools, prompts for dangerous). Add `PermissionModeAuto PermissionMode = "auto"` in `internal/shared/options.go`. |
+| #796 | --thinking flag for adaptive/disabled | Apr 7 | fix | P1 | 4 | pending | - | Python fixed CLI flags: adaptive -> `--thinking adaptive`, disabled -> `--thinking disabled` (not budget tokens). Update CLI builder in `internal/cli/command.go` to handle ThinkingConfig types correctly. |
+| #797 | exclude_dynamic_sections on SystemPromptPreset | Apr 8 | feat | P1 | 4 | pending | - | Python added exclude_dynamic_sections bool to SystemPromptPreset for cross-user prompt caching. Add ExcludeDynamicSections bool to SystemPromptPreset struct (create if needed), pass as CLI flag. |
+
+### P2 - Medium (Bug Fixes)
+
+| Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
+|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
+| #630 | Fix string prompt closing stdin before MCP init | Mar 4 | fix | P2 | 7 | pending | - | Python fixed race: string prompt closed stdin before SDK MCP servers initialized. Check Go subprocess stdin in `internal/subprocess/` - verify stdin stays open until MCP init completes (wait for initialize response before closing write end). |
+| #686 | default-if-absent for CLAUDE_CODE_ENTRYPOINT | Mar 16 | fix | P2 | 7 | pending | - | Python only sets CLAUDE_CODE_ENTRYPOINT if not already in env (matching TS SDK). Check `internal/subprocess/config.go` - change from unconditional set to set-if-absent so users can override. |
+| #717 | propagate is_error from SDK MCP tool results | Mar 25 | fix | P2 | 7 | pending | - | Python fixed is_error flag propagation from McpToolResult to CLI. Check `internal/control/mcp.go` - verify IsError on McpToolResult is included in JSON response to CLI. |
+| #719 | add missing dontAsk permission mode | Mar 25 | fix | P2 | 7 | pending | - | Python added "dontAsk" to PermissionMode (was missing despite being valid CLI mode). Add `PermissionModeDontAsk PermissionMode = "dontAsk"`. Check if Go SDK already has this. |
+| #720 | remove duplicate version warning | Mar 25 | fix | P2 | 7 | pending | - | Python removed duplicate CLI version warning. Check `internal/cli/version.go` - verify warning fires only once per session. |
+| #723 | skip non-JSON lines on CLI stdout | Mar 25 | fix | P2 | 7 | pending | - | Python skips non-JSON debug lines on stdout (DEBUG env in Docker/Lambda). Check `internal/parser/parser.go` - verify graceful skip of lines not starting with `{`. May already be handled by speculative parsing. |
+| #725 | handle resource_link/embedded resource in SDK MCP | Mar 25 | fix | P2 | 7 | pending | - | Python added resource_link and embedded_resource content types in SDK MCP tool responses. Check `mcp.go` - add support for these content types in McpContent or pass through as-is. |
+| #729 | SIGKILL fallback when SIGTERM blocks | Mar 26 | fix | P2 | 7 | pending | - | Python added SIGKILL escalation when SIGTERM handler blocks. Go SDK has SIGTERM->wait->SIGKILL in `internal/subprocess/process.go` - verify wait timeout (5s) and SIGKILL fires if process doesn't exit. |
+| #731 | remove stdin timeout for hooks/SDK MCP | Mar 25 | fix | P2 | 7 | pending | - | Python removed write timeout on stdin for hook/MCP responses (can take long). Check `internal/subprocess/io.go` - verify no artificial timeout on control response writes. |
+| #732 | filter CLAUDECODE env var from subprocess | Mar 26 | fix | P2 | 7 | pending | - | Python filters CLAUDECODE env var from subprocess to prevent child CLI inheritance. Check `internal/subprocess/config.go` - add CLAUDECODE to filtered env vars. |
+| #743 | pass initialize_timeout from env var | Mar 26 | fix | P2 | 7 | pending | - | Python reads CLAUDE_CODE_STREAM_CLOSE_TIMEOUT env var to override initialize timeout. Check if Go SDK respects this, add support if not. |
+| #756 | forward maxResultSizeChars via _meta | Apr 2 | fix | P2 | 7 | pending | - | Python forwards maxResultSizeChars in _meta of MCP tool results for large results (>50K chars). Add _meta.maxResultSizeChars to tool result JSON when exceeding threshold. |
+| #769 | send string prompt in connect() | Mar 28 | fix | P2 | 7 | pending | - | Python fixed connect(prompt="...") silently dropping prompt. Verify Go Client.Connect() sends prompt via stdin after connection established. |
+| #778 | omit --setting-sources when empty | Mar 30 | fix | P2 | 7 | pending | - | Python omits --setting-sources when empty instead of passing empty value. Check `internal/cli/command.go` - verify empty SettingSources doesn't produce `--setting-sources ""`. |
+| #780 | background task for string prompts with hooks/MCP | Mar 30 | fix | P2 | 7 | pending | - | Python fixed deadlock with string prompt + hooks/MCP by spawning stdin write as background task. Verify Go SDK has no deadlock when hooks/MCP configured with string prompt. |
+
+### Skip
+
+| Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
+|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
+| #451 | Skip jobs requiring secrets from forks | Jan 5 | ci | skip | - | skip | - | CI workflow |
+| #467 | Update claude-code actions to @v1 | Jan 12 | ci | skip | - | skip | - | CI workflow |
+| #485 | Make permission callback e2e test robust | Jan 16 | test | skip | - | skip | - | Python e2e test |
+| #486 | Release v0.1.20 | Jan 16 | chore | skip | - | skip | - | Python release |
+| #488 | Extract build-and-publish workflow | Jan 21 | ci | skip | - | skip | - | CI workflow |
+| #503 | Release v0.1.21 | Jan 21 | chore | skip | - | skip | - | Python release |
+| #504 | Fix release job permissions | Jan 22 | ci | skip | - | skip | - | CI workflow |
+| #511 | Fix SSH remote URL in auto-release | Jan 23 | ci | skip | - | skip | - | CI workflow |
+| #512 | Release v0.1.22 | Jan 23 | chore | skip | - | skip | - | Python release |
+| #536 | Add debug output to MCP e2e tests | Jan 30 | test | skip | - | skip | - | Python test |
+| #537 | Pin CI to Python 3.13 | Jan 30 | ci | skip | - | skip | - | CI workflow |
+| #538 | Enforce sequential tool execution in MCP e2e | Jan 30 | test | skip | - | skip | - | Python test |
+| #539 | Simplify release flow + RELEASING.md | Jan 30 | ci | skip | - | skip | - | CI workflow |
+| #556 | Update Claude model to opus-4-6 in CI | Feb 7 | ci | skip | - | skip | - | CI workflow |
+| #661 | Publish macOS x86_64 wheel | Mar 9 | ci | skip | - | skip | - | Python wheel |
+| #662 | Upload check wheels as artifacts | Mar 12 | ci | skip | - | skip | - | Python wheel |
+| #700 | Harden PyPI publish | Mar 20 | ci | skip | - | skip | - | PyPI infra |
+| #705 | Daily PyPI storage quota monitoring | Mar 20 | ci | skip | - | skip | - | PyPI infra |
+| #708 | Retry install.sh fetch on 429 | Mar 24 | ci | skip | - | skip | - | Build infra |
+| #722 | Defer CLI discovery to connect() | Mar 25 | fix | skip | - | skip | - | Python async event loop specific |
+| #736 | Convert TypedDict input_schema to JSON Schema | Mar 26 | fix | skip | - | skip | - | Python TypedDict specific |
+| #746 | Resolve cross-task cancel scope RuntimeError | Mar 26 | fix | skip | - | skip | - | Python async/anyio specific |
+| #760 | Increase test-examples timeout | Mar 28 | ci | skip | - | skip | - | CI timeout |
+| #761 | typing_extensions.TypedDict on Python 3.10 | Mar 27 | fix | skip | - | skip | - | Python 3.10 compat |
+| #762 | Annotated for per-parameter descriptions in @tool | Mar 28 | feat | skip | - | skip | - | Python typing.Annotated feature |
+
+---
+
+## How to Update
+
+1. **Starting work:** Set Go Status to `in-progress`
+2. **PR merged:** Set Go Status to `done`, fill Go PR column with `#N`
+3. **Not applicable:** Set Go Status to `skip`, add reason in Notes
+4. **New Python PRs (after April 12, 2026):** Add rows to the table, update snapshot date
+5. **Keep summary stats in sync** with the table counts
+6. **Re-evaluate priorities** as waves complete - some P2s may become P0 based on user reports

--- a/docs/tracking/README.md
+++ b/docs/tracking/README.md
@@ -21,9 +21,9 @@ PRs merged after April 12, 2026 are NOT tracked here. Add them manually and upda
 |:---------|:------|:------------|
 | P0 | 8 | Message types/parsing - broken deserialization if missing |
 | P1 | 25 | New client methods, options, control protocol features |
-| P2 | 15 | Bug fixes - evaluate Go applicability |
-| Skip | 24 | CI/CD, Python typing, async-specific, PyPI/wheel, CLI bumps |
-| **Actionable** | **48** | |
+| P2 | 16 | Bug fixes - evaluate Go applicability |
+| Skip | 31 | CI/CD, Python typing, async-specific, PyPI/wheel, CLI bumps |
+| **Actionable** | **49** | |
 
 ## Priority Scale
 
@@ -69,6 +69,7 @@ Replay in order. Each row is one Python SDK PR, sorted by merge date.
 | 12 | #622 | list_sessions / get_session_messages | Mar 3 | feat | P1 | 3 | pending | - | Python added top-level list_sessions() and get_session_messages(session_id) using CLI flags --list-sessions and --get-session-messages. Returns []SDKSessionInfo and []SessionMessage. Add package-level functions, SDKSessionInfo struct (session_id, summary, last_modified, file_size, custom_title, first_prompt, git_branch, cwd), SessionMessage struct (type, uuid, session_id, message, parent_tool_use_id). Standalone CLI invocations, not control protocol. |
 | 13 | #628 | agent_id/agent_type in hook inputs | Mar 3 | feat | P1 | 2 | pending | - | Python added optional agent_id and agent_type to PreToolUseHookInput and PostToolUseHookInput via _SubagentContextMixin. Identifies which agent triggered tool use. Add `AgentID *string` and `AgentType *string` to both hook input structs in `internal/control/types_hook.go`. |
 | 14 | #630 | Fix string prompt closing stdin before MCP init | Mar 4 | fix | P2 | 7 | pending | - | Python fixed race: string prompt closed stdin before SDK MCP servers initialized. Check Go subprocess stdin in `internal/subprocess/` - verify stdin stays open until MCP init completes (wait for initialize response before closing write end). |
+| 14a | #642 | Wait for graceful subprocess shutdown before SIGTERM | Mar 19 | fix | P2 | 7 | pending | - | Python added a graceful wait period before sending SIGTERM, allowing the subprocess to finish in-flight work. Check Go process lifecycle in `internal/subprocess/process.go` - verify shutdown sequence gives process time to flush before SIGTERM. |
 | 15 | #648 | Typed RateLimitEvent message | Mar 12 | feat | P0 | 1 | pending | - | Python added dedicated RateLimitEvent message type (not SystemMessage) with RateLimitInfo: status, resets_at, rate_limit_type, utilization, overage_status, overage_resets_at, overage_disabled_reason, raw. Add RateLimitEvent struct implementing Message interface, RateLimitInfo struct, parser update to recognize type "rate_limit" in `internal/parser/parser.go`. Also carries uuid and session_id. |
 | 16 | #668 | rename_session | Mar 12 | feat | P1 | 3 | pending | - | Python added rename_session(session_id, new_name) to rename a session's custom title. Add RenameSession(ctx, sessionID, newName string) package-level function. Uses CLI flag or control request. |
 | 17 | #670 | tag_session with Unicode sanitization | Mar 12 | feat | P1 | 3 | pending | - | Python added tag_session(session_id, tag) with Unicode sanitization (strips non-printable chars, validates length). Add TagSession(ctx, sessionID, tag string) package-level function with equivalent Unicode validation. |
@@ -111,6 +112,8 @@ Not applicable to Go SDK. Listed for completeness so nothing falls through crack
 | Py PR | Title | Merged | Reason |
 |:------|:------|:-------|:-------|
 | #451 | Skip jobs requiring secrets from forks | Jan 5 | CI workflow |
+| #442 | Update Claude Agent SDK documentation link | Jan 8 | Docs-only |
+| #465 | Release v0.1.19 | Jan 8 | Python release |
 | #467 | Update claude-code actions to @v1 | Jan 12 | CI workflow |
 | #485 | Make permission callback e2e test robust | Jan 16 | Python e2e test |
 | #486 | Release v0.1.20 | Jan 16 | Python release |
@@ -124,9 +127,13 @@ Not applicable to Go SDK. Listed for completeness so nothing falls through crack
 | #538 | Enforce sequential tool execution in MCP e2e | Jan 30 | Python test |
 | #539 | Simplify release flow + RELEASING.md | Jan 30 | CI workflow |
 | #556 | Update Claude model to opus-4-6 in CI | Feb 7 | CI workflow |
+| #644 | Enable fine-grained tool streaming | Mar 6 | Reverted by #671 |
 | #661 | Publish macOS x86_64 wheel | Mar 9 | Python wheel |
 | #662 | Upload check wheels as artifacts | Mar 12 | Python wheel |
+| #649 | Clarify allowed_tools as permission allowlist | Mar 10 | Docs-only |
+| #671 | Revert fine-grained tool streaming (#644) | Mar 10 | Revert of #644 |
 | #700 | Harden PyPI publish | Mar 20 | PyPI infra |
+| #707 | Release v0.1.49 | Mar 20 | Python release |
 | #705 | Daily PyPI storage quota monitoring | Mar 20 | PyPI infra |
 | #708 | Retry install.sh fetch on 429 | Mar 24 | Build infra |
 | #722 | Defer CLI discovery to connect() | Mar 25 | Python async event loop specific |

--- a/docs/tracking/README.md
+++ b/docs/tracking/README.md
@@ -1,6 +1,6 @@
 # Python SDK PR Replay Tracker
 
-Tracks all Python SDK PRs that need to be replayed into the Go SDK to restore parity. PRs are listed in merge-order - replay them top to bottom.
+Tracks all Python SDK PRs that need to be replayed into the Go SDK to restore parity. Replay top to bottom within each phase.
 
 ## Snapshot
 
@@ -17,93 +17,90 @@ PRs merged after April 12, 2026 are NOT tracked here. Add them manually and upda
 
 ## Summary
 
-| Priority | Count | Description |
-|:---------|:------|:------------|
-| P0 | 8 | Message types/parsing - broken deserialization if missing |
-| P1 | 25 | New client methods, options, control protocol features |
-| P2 | 16 | Bug fixes - evaluate Go applicability |
-| Skip | 31 | CI/CD, Python typing, async-specific, PyPI/wheel, CLI bumps |
-| **Actionable** | **49** | |
-
-## Priority Scale
-
-- **P0 (Critical):** New fields or types on messages. Missing these means the Go SDK silently drops data from CLI responses or fails to deserialize.
-- **P1 (High):** New client methods, configuration options, or control protocol features. The SDK works without these but lacks functionality the Python SDK offers.
-- **P2 (Medium):** Bug fixes from the Python SDK. Each must be evaluated against the Go codebase - some may already be handled differently, some may need porting.
-- **Skip:** Not applicable to Go SDK. CI/CD workflows, Python-specific typing (typing_extensions, TypedDict compat, Annotated), Python async-specific fixes (cancel scope, event loop), PyPI/wheel publishing, CLI version bumps, docs-only changes.
-
-## Implementation Waves (Reference)
-
-Waves group related PRs by area. Use as a reference when working on a PR to see what else touches the same files.
-
-| Wave | Area | PRs | Go Files |
-|:-----|:-----|:----|:---------|
-| 1 | Type Safety (P0) | #506, #598, #619, #621, #648, #685, #718, #749 | `internal/shared/message.go`, `internal/parser/parser.go` |
-| 2 | Hook System | #535, #545, #628 | `internal/control/types_hook.go`, `internal/control/hooks.go` |
-| 3 | Session Management | #622, #667, #668, #670, #744, #750 | `client.go`, `options.go`, `internal/control/` |
-| 4 | Agent/Options | #468, #565, #591, #684, #747, #759, #782, #785, #796, #797 | `internal/shared/options.go`, `options.go`, `internal/cli/command.go` |
-| 5 | MCP Enhancements | #516, #551, #620 | `mcp.go`, `client.go`, `internal/control/` |
-| 6 | New Client Methods | #751, #754, #764 | `client.go`, `internal/control/types.go`, `transport.go` |
-| 7 | Bug Fix Audit | #630, #686, #717, #719, #720, #723, #725, #729, #731, #732, #743, #756, #769, #778, #780 | various |
+| Category | Count |
+|:---------|:------|
+| Actionable | 49 |
+| Skip (CI/CD, Python-specific, docs-only) | 31 |
 
 ---
 
-## Replay Queue (Chronological)
+## Phase 1 - Jan 26 to Feb 20
 
-Replay in order. Each row is one Python SDK PR, sorted by merge date.
+| # | Py PR | Title | Merged | Cat | Go Status | Go PR | Notes |
+|:--|:------|:------|:-------|:----|:----------|:------|:------|
+| - | #495 | tool_use_result on UserMessage | Jan 23 | feat | done | #99 | Added ToolUseResult map[string]any field to UserMessage with HasToolUseResult()/GetToolUseResult() helpers |
+| 1 | #516 | get_mcp_status() method | Jan 26 | feat | pending | - | Python added get_mcp_status() returning McpStatusResponse with list of McpServerStatus (name, status, serverInfo, error, config, scope, tools). Add GetMcpStatus(ctx) to Client interface, control request subtype "get_mcp_status", McpServerStatus/McpStatusResponse types in `internal/control/types.go`, wire through Transport. |
+| 2 | #535 | PostToolUseFailure hook event | Jan 30 | feat | pending | - | Python added "PostToolUseFailure" hook event firing when tool execution fails (distinct from PostToolUse on success). Add `HookEventPostToolUseFailure = "PostToolUseFailure"` constant, PostToolUseFailureHookInput (embeds BaseHookInput, has ToolName, ToolInput, Error), PostToolUseFailureHookSpecificOutput in `internal/control/types_hook.go`. |
+| 3 | #506 | Properly populate AssistantMessage error field | Feb 3 | fix | pending | - | Python fixed AssistantMessage.error not being populated from JSON during deserialization. Go SDK has AssistantMessage.Error *AssistantMessageError - verify UnmarshalJSON in `internal/shared/message.go` correctly parses the `error` object with type/message fields. Test with rate_limit, billing_error, server_error payloads. |
+| 4 | #545 | Missing hook events + fix fields | Feb 3 | feat | pending | - | Python added 3 hook events: "Notification" (system notifications), "SubagentStart" (subagent spawned), "PermissionRequest" (permission requested). Each has HookInput type. Also fixed existing hook fields. Add 3 HookEvent constants, 3 HookInput structs, 3 HookSpecificOutput structs in `internal/control/types_hook.go`. Add SubagentContextMixin equivalent (AgentID, AgentType *string) to relevant inputs. |
+| 5 | #551 | MCP tool annotations | Feb 5 | feat | pending | - | Python added McpToolAnnotations (readOnly, destructive, openWorld bools) and McpToolInfo (name, description, annotations). Returned in MCP server status and tool listings. Add structs in `mcp.go` or `internal/shared/options.go`. Wire into McpServerStatus.Tools. |
+| 6 | #468 | Send agent definitions via initialize request | Feb 5 | feat | pending | - | Python sends agents in initialize control request instead of --agents CLI flag. Add `Agents map[string]AgentDefinition` to InitializeRequest in `internal/control/types.go`. Update `internal/control/protocol.go` to include agents. Remove/deprecate --agents flag in `internal/cli/`. |
+| 7 | #565 | ThinkingConfig types and effort option | Feb 11 | feat | pending | - | Python replaced max_thinking_tokens with ThinkingConfig union: ThinkingConfigAdaptive (type="adaptive"), ThinkingConfigEnabled (type="enabled", budget_tokens), ThinkingConfigDisabled (type="disabled"). Added effort option ("low"/"medium"/"high"/"max"). Add ThinkingConfig interface + 3 structs, WithThinking(), WithEffort() in `options.go`. Update CLI flags: adaptive -> `--thinking adaptive`, disabled -> `--thinking disabled`, enabled -> `--thinking-budget N`. Deprecate WithMaxThinkingTokens(). |
+| 8 | #598 | Handle unknown message types gracefully | Feb 20 | fix | pending | - | Python returns a raw/passthrough message instead of crashing on unrecognized `type` field. Go SDK parser in `internal/parser/parser.go` likely returns error on unknown types. Change to return RawMessage or fallback type so new CLI message types don't break existing consumers. Forward-compatibility. |
 
-| # | Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
-|:--|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
-| - | #495 | tool_use_result on UserMessage | Jan 23 | feat | - | - | done | #99 | Added ToolUseResult map[string]any field to UserMessage with HasToolUseResult()/GetToolUseResult() helpers |
-| 1 | #516 | get_mcp_status() method | Jan 26 | feat | P1 | 5 | pending | - | Python added get_mcp_status() returning McpStatusResponse with list of McpServerStatus (name, status, serverInfo, error, config, scope, tools). Add GetMcpStatus(ctx) to Client interface, control request subtype "get_mcp_status", McpServerStatus/McpStatusResponse types in `internal/control/types.go`, wire through Transport. |
-| 2 | #535 | PostToolUseFailure hook event | Jan 30 | feat | P1 | 2 | pending | - | Python added "PostToolUseFailure" hook event firing when tool execution fails (distinct from PostToolUse on success). Add `HookEventPostToolUseFailure = "PostToolUseFailure"` constant, PostToolUseFailureHookInput (embeds BaseHookInput, has ToolName, ToolInput, Error), PostToolUseFailureHookSpecificOutput in `internal/control/types_hook.go`. |
-| 3 | #506 | Properly populate AssistantMessage error field | Feb 3 | fix | P0 | 1 | pending | - | Python fixed AssistantMessage.error not being populated from JSON during deserialization. Go SDK has AssistantMessage.Error *AssistantMessageError - verify UnmarshalJSON in `internal/shared/message.go` correctly parses the `error` object with type/message fields. Test with rate_limit, billing_error, server_error payloads. |
-| 4 | #545 | Missing hook events + fix fields | Feb 3 | feat | P1 | 2 | pending | - | Python added 3 hook events: "Notification" (system notifications), "SubagentStart" (subagent spawned), "PermissionRequest" (permission requested). Each has HookInput type. Also fixed existing hook fields. Add 3 HookEvent constants, 3 HookInput structs, 3 HookSpecificOutput structs in `internal/control/types_hook.go`. Add SubagentContextMixin equivalent (AgentID, AgentType *string) to relevant inputs. |
-| 5 | #551 | MCP tool annotations | Feb 5 | feat | P1 | 5 | pending | - | Python added McpToolAnnotations (readOnly, destructive, openWorld bools) and McpToolInfo (name, description, annotations). Returned in MCP server status and tool listings. Add structs in `mcp.go` or `internal/shared/options.go`. Wire into McpServerStatus.Tools. |
-| 6 | #468 | Send agent definitions via initialize request | Feb 5 | feat | P1 | 4 | pending | - | Python sends agents in initialize control request instead of --agents CLI flag. Add `Agents map[string]AgentDefinition` to InitializeRequest in `internal/control/types.go`. Update `internal/control/protocol.go` to include agents. Remove/deprecate --agents flag in `internal/cli/`. |
-| 7 | #565 | ThinkingConfig types and effort option | Feb 11 | feat | P1 | 4 | pending | - | Python replaced max_thinking_tokens with ThinkingConfig union: ThinkingConfigAdaptive (type="adaptive"), ThinkingConfigEnabled (type="enabled", budget_tokens), ThinkingConfigDisabled (type="disabled"). Added effort option ("low"/"medium"/"high"/"max"). Add ThinkingConfig interface + 3 structs, WithThinking(), WithEffort() in `options.go`. Update CLI flags: adaptive -> `--thinking adaptive`, disabled -> `--thinking disabled`, enabled -> `--thinking-budget N`. Deprecate WithMaxThinkingTokens(). |
-| 8 | #598 | Handle unknown message types gracefully | Feb 20 | fix | P0 | 1 | pending | - | Python returns a raw/passthrough message instead of crashing on unrecognized `type` field. Go SDK parser in `internal/parser/parser.go` likely returns error on unknown types. Change to return RawMessage or fallback type so new CLI message types don't break existing consumers. Forward-compatibility. |
-| 9 | #619 | stop_reason on ResultMessage | Mar 3 | feat | P0 | 1 | pending | - | Python added `stop_reason: str` to ResultMessage (values: "end_turn", "max_tokens", "stop_sequence"). Add `StopReason string` field with `json:"stop_reason"` to ResultMessage in `internal/shared/message.go`. Wire through UnmarshalJSON. |
-| 10 | #620 | MCP control methods + typed McpServerStatus | Mar 3 | feat | P1 | 5 | pending | - | Python added reconnect_mcp_server(name) and toggle_mcp_server(name, enabled). Also typed McpServerStatus with McpServerConnectionStatus enum ("connected"/"failed"/"needs-auth"/"pending"/"disabled") and McpServerInfo (name, version). Add ReconnectMcpServer(ctx, name) and ToggleMcpServer(ctx, name, enabled) on Client interface, new control request subtypes, wire through Transport. |
-| 11 | #621 | Typed TaskStarted/TaskProgress/TaskNotification | Mar 3 | feat | P0 | 1 | pending | - | Python created typed SystemMessage subclasses: TaskStartedMessage (task_id, prompt), TaskProgressMessage (task_id, tool_name, progress), TaskNotificationMessage (task_id, status, usage). Go SDK uses generic SystemMessage with Data map. Add concrete structs for each subtype, parse on SystemMessage.Subtype in `internal/shared/message.go`. Add TaskUsage struct (total_tokens, tool_uses, duration_ms). TaskNotificationStatus enum: "completed", "failed", "stopped". |
-| 12 | #622 | list_sessions / get_session_messages | Mar 3 | feat | P1 | 3 | pending | - | Python added top-level list_sessions() and get_session_messages(session_id) using CLI flags --list-sessions and --get-session-messages. Returns []SDKSessionInfo and []SessionMessage. Add package-level functions, SDKSessionInfo struct (session_id, summary, last_modified, file_size, custom_title, first_prompt, git_branch, cwd), SessionMessage struct (type, uuid, session_id, message, parent_tool_use_id). Standalone CLI invocations, not control protocol. |
-| 13 | #628 | agent_id/agent_type in hook inputs | Mar 3 | feat | P1 | 2 | pending | - | Python added optional agent_id and agent_type to PreToolUseHookInput and PostToolUseHookInput via _SubagentContextMixin. Identifies which agent triggered tool use. Add `AgentID *string` and `AgentType *string` to both hook input structs in `internal/control/types_hook.go`. |
-| 14 | #630 | Fix string prompt closing stdin before MCP init | Mar 4 | fix | P2 | 7 | pending | - | Python fixed race: string prompt closed stdin before SDK MCP servers initialized. Check Go subprocess stdin in `internal/subprocess/` - verify stdin stays open until MCP init completes (wait for initialize response before closing write end). |
-| 14a | #642 | Wait for graceful subprocess shutdown before SIGTERM | Mar 19 | fix | P2 | 7 | pending | - | Python added a graceful wait period before sending SIGTERM, allowing the subprocess to finish in-flight work. Check Go process lifecycle in `internal/subprocess/process.go` - verify shutdown sequence gives process time to flush before SIGTERM. |
-| 15 | #648 | Typed RateLimitEvent message | Mar 12 | feat | P0 | 1 | pending | - | Python added dedicated RateLimitEvent message type (not SystemMessage) with RateLimitInfo: status, resets_at, rate_limit_type, utilization, overage_status, overage_resets_at, overage_disabled_reason, raw. Add RateLimitEvent struct implementing Message interface, RateLimitInfo struct, parser update to recognize type "rate_limit" in `internal/parser/parser.go`. Also carries uuid and session_id. |
-| 16 | #668 | rename_session | Mar 12 | feat | P1 | 3 | pending | - | Python added rename_session(session_id, new_name) to rename a session's custom title. Add RenameSession(ctx, sessionID, newName string) package-level function. Uses CLI flag or control request. |
-| 17 | #670 | tag_session with Unicode sanitization | Mar 12 | feat | P1 | 3 | pending | - | Python added tag_session(session_id, tag) with Unicode sanitization (strips non-printable chars, validates length). Add TagSession(ctx, sessionID, tag string) package-level function with equivalent Unicode validation. |
-| 18 | #685 | Preserve per-turn usage on AssistantMessage | Mar 16 | feat | P0 | 1 | pending | - | Python added `usage: dict` to AssistantMessage for per-turn token stats (input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens). Add `Usage map[string]any` with `json:"usage,omitempty"` to AssistantMessage in `internal/shared/message.go`. |
-| 19 | #684 | skills/memory/mcpServers on AgentDefinition | Mar 16 | feat | P1 | 4 | pending | - | Python added skills (list), memory (config), mcpServers (map) to AgentDefinition. Add `Skills []any`, `Memory any`, `McpServers map[string]McpServerConfig` with JSON tags to AgentDefinition in `internal/shared/options.go`. |
-| 20 | #686 | default-if-absent for CLAUDE_CODE_ENTRYPOINT | Mar 16 | fix | P2 | 7 | pending | - | Python only sets CLAUDE_CODE_ENTRYPOINT if not already in env (matching TS SDK). Check `internal/subprocess/config.go` - change from unconditional set to set-if-absent so users can override. |
-| 21 | #667 | tag/created_at on SDKSessionInfo + get_session_info | Mar 20 | feat | P1 | 3 | pending | - | Python added tag and created_at fields to SDKSessionInfo. Added get_session_info(session_id) function. Add `Tag *string`, `CreatedAt *string` to SDKSessionInfo. Add GetSessionInfo(ctx, sessionID) package-level function. |
-| 22 | #591 | SystemPromptFile support | Mar 25 | feat | P1 | 4 | pending | - | Python added SystemPromptFile TypedDict passing --system-prompt-file to CLI. Add SystemPromptFile struct (Path string), update system_prompt option handling, add --system-prompt-file flag in `internal/cli/command.go`. |
-| 23 | #717 | propagate is_error from SDK MCP tool results | Mar 25 | fix | P2 | 7 | pending | - | Python fixed is_error flag propagation from McpToolResult to CLI. Check `internal/control/mcp.go` - verify IsError on McpToolResult is included in JSON response to CLI. |
-| 24 | #718 | Preserve dropped fields on AssistantMessage/ResultMessage | Mar 25 | feat | P0 | 1 | pending | - | Python captures unknown JSON fields into `extra_fields: dict` catch-all to prevent data loss when CLI adds new fields. Add `ExtraFields map[string]any` to AssistantMessage and ResultMessage, populated during UnmarshalJSON by collecting keys not in known fields. Forward-compatibility pattern. |
-| 25 | #719 | add missing dontAsk permission mode | Mar 25 | fix | P2 | 7 | pending | - | Python added "dontAsk" to PermissionMode (was missing despite being valid CLI mode). Add `PermissionModeDontAsk PermissionMode = "dontAsk"`. Check if Go SDK already has this. |
-| 26 | #720 | remove duplicate version warning | Mar 25 | fix | P2 | 7 | pending | - | Python removed duplicate CLI version warning. Check `internal/cli/version.go` - verify warning fires only once per session. |
-| 27 | #723 | skip non-JSON lines on CLI stdout | Mar 25 | fix | P2 | 7 | pending | - | Python skips non-JSON debug lines on stdout (DEBUG env in Docker/Lambda). Check `internal/parser/parser.go` - verify graceful skip of lines not starting with `{`. May already be handled by speculative parsing. |
-| 28 | #725 | handle resource_link/embedded resource in SDK MCP | Mar 25 | fix | P2 | 7 | pending | - | Python added resource_link and embedded_resource content types in SDK MCP tool responses. Check `mcp.go` - add support for these content types in McpContent or pass through as-is. |
-| 29 | #731 | remove stdin timeout for hooks/SDK MCP | Mar 25 | fix | P2 | 7 | pending | - | Python removed write timeout on stdin for hook/MCP responses (can take long). Check `internal/subprocess/io.go` - verify no artificial timeout on control response writes. |
-| 30 | #729 | SIGKILL fallback when SIGTERM blocks | Mar 26 | fix | P2 | 7 | pending | - | Python added SIGKILL escalation when SIGTERM handler blocks. Go SDK has SIGTERM->wait->SIGKILL in `internal/subprocess/process.go` - verify wait timeout (5s) and SIGKILL fires if process doesn't exit. |
-| 31 | #732 | filter CLAUDECODE env var from subprocess | Mar 26 | fix | P2 | 7 | pending | - | Python filters CLAUDECODE env var from subprocess to prevent child CLI inheritance. Check `internal/subprocess/config.go` - add CLAUDECODE to filtered env vars. |
-| 32 | #744 | fork_session, delete_session, offset pagination | Mar 26 | feat | P1 | 3 | pending | - | Python added fork_session(session_id) -> ForkSessionResult (new_session_id), delete_session(session_id), offset/limit params on list_sessions(). Add ForkSession(), DeleteSession() functions, ForkSessionResult struct, update ListSessions with pagination. |
-| 33 | #747 | task_budget option | Mar 26 | feat | P1 | 4 | pending | - | Python added TaskBudget TypedDict (total int) and task_budget option. Passed as --task-budget CLI flag. Add TaskBudget struct, WithTaskBudget() in `options.go`, CLI flag in `internal/cli/`. |
-| 34 | #743 | pass initialize_timeout from env var | Mar 26 | fix | P2 | 7 | pending | - | Python reads CLAUDE_CODE_STREAM_CLOSE_TIMEOUT env var to override initialize timeout. Check if Go SDK respects this, add support if not. |
-| 35 | #749 | errors field on ResultMessage | Mar 27 | fix | P0 | 1 | pending | - | Python added `errors: list[str]` to ResultMessage for non-fatal session errors. Add `Errors []string` with `json:"errors,omitempty"` to ResultMessage. Distinct from IsError (fatal failure flag). |
-| 36 | #759 | disallowedTools/maxTurns/initialPrompt on AgentDefinition | Mar 27 | feat | P1 | 4 | pending | - | Python added disallowedTools ([]string), maxTurns (int), initialPrompt (string) to AgentDefinition. Add `DisallowedTools []string`, `MaxTurns *int`, `InitialPrompt *string` with JSON tags to AgentDefinition. |
-| 37 | #750 | session_id on ClaudeAgentOptions | Mar 28 | feat | P1 | 3 | pending | - | Python added session_id option for custom session IDs. Passed as --session-id CLI flag. Add WithSessionID(id string) option, `SessionID *string` to Options, CLI flag in `internal/cli/`. |
-| 38 | #754 | tool_use_id/agent_id in ToolPermissionContext | Mar 28 | feat | P1 | 6 | pending | - | Python added tool_use_id and agent_id to ToolPermissionContext for richer permission callback context. Add `ToolUseID string` and `AgentID string` to ToolPermissionContext in `internal/control/types.go`. |
-| 39 | #764 | get_context_usage() | Mar 28 | feat | P1 | 6 | pending | - | Python added get_context_usage() returning ContextUsageResponse: categories ([]ContextUsageCategory with name/tokens/color/isDeferred), totalTokens, maxTokens, percentage, model, optional autoCompactThreshold/mcpTools/agents. Add GetContextUsage(ctx) to Client, ContextUsageResponse/ContextUsageCategory structs, control request subtype, wire through Transport. |
-| 40 | #751 | control_cancel_request handling | Mar 28 | feat | P1 | 6 | pending | - | Python handles control_cancel_request from CLI to cancel pending control requests (e.g., timed-out permission callbacks). Update `internal/control/protocol.go` to handle incoming "cancel_request" by canceling context of pending request by request_id. |
-| 41 | #769 | send string prompt in connect() | Mar 28 | fix | P2 | 7 | pending | - | Python fixed connect(prompt="...") silently dropping prompt. Verify Go Client.Connect() sends prompt via stdin after connection established. |
-| 42 | #778 | omit --setting-sources when empty | Mar 30 | fix | P2 | 7 | pending | - | Python omits --setting-sources when empty instead of passing empty value. Check `internal/cli/command.go` - verify empty SettingSources doesn't produce `--setting-sources ""`. |
-| 43 | #780 | background task for string prompts with hooks/MCP | Mar 30 | fix | P2 | 7 | pending | - | Python fixed deadlock with string prompt + hooks/MCP by spawning stdin write as background task. Verify Go SDK has no deadlock when hooks/MCP configured with string prompt. |
-| 44 | #782 | background/effort/permissionMode on AgentDefinition | Mar 31 | feat | P1 | 4 | pending | - | Python added background (bool), effort (string), permissionMode (PermissionMode) to AgentDefinition. Add `Background *bool`, `Effort *string`, `PermissionMode *PermissionMode` with JSON tags. |
-| 45 | #756 | forward maxResultSizeChars via _meta | Apr 2 | fix | P2 | 7 | pending | - | Python forwards maxResultSizeChars in _meta of MCP tool results for large results (>50K chars). Add _meta.maxResultSizeChars to tool result JSON when exceeding threshold. |
-| 46 | #785 | 'auto' PermissionMode | Apr 7 | feat | P1 | 4 | pending | - | Python added "auto" PermissionMode (auto-approves safe tools, prompts for dangerous). Add `PermissionModeAuto PermissionMode = "auto"` in `internal/shared/options.go`. |
-| 47 | #796 | --thinking flag for adaptive/disabled | Apr 7 | fix | P1 | 4 | pending | - | Python fixed CLI flags: adaptive -> `--thinking adaptive`, disabled -> `--thinking disabled` (not budget tokens). Update CLI builder in `internal/cli/command.go` to handle ThinkingConfig types correctly. |
-| 48 | #797 | exclude_dynamic_sections on SystemPromptPreset | Apr 8 | feat | P1 | 4 | pending | - | Python added exclude_dynamic_sections bool to SystemPromptPreset for cross-user prompt caching. Add ExcludeDynamicSections bool to SystemPromptPreset struct (create if needed), pass as CLI flag. |
+---
+
+## Phase 2 - Mar 3 to Mar 16
+
+| # | Py PR | Title | Merged | Cat | Go Status | Go PR | Notes |
+|:--|:------|:------|:-------|:----|:----------|:------|:------|
+| 9 | #619 | stop_reason on ResultMessage | Mar 3 | feat | pending | - | Python added `stop_reason: str` to ResultMessage (values: "end_turn", "max_tokens", "stop_sequence"). Add `StopReason string` field with `json:"stop_reason"` to ResultMessage in `internal/shared/message.go`. Wire through UnmarshalJSON. |
+| 10 | #620 | MCP control methods + typed McpServerStatus | Mar 3 | feat | pending | - | Python added reconnect_mcp_server(name) and toggle_mcp_server(name, enabled). Also typed McpServerStatus with McpServerConnectionStatus enum ("connected"/"failed"/"needs-auth"/"pending"/"disabled") and McpServerInfo (name, version). Add ReconnectMcpServer(ctx, name) and ToggleMcpServer(ctx, name, enabled) on Client interface, new control request subtypes, wire through Transport. |
+| 11 | #621 | Typed TaskStarted/TaskProgress/TaskNotification | Mar 3 | feat | pending | - | Python created typed SystemMessage subclasses: TaskStartedMessage (task_id, prompt), TaskProgressMessage (task_id, tool_name, progress), TaskNotificationMessage (task_id, status, usage). Go SDK uses generic SystemMessage with Data map. Add concrete structs for each subtype, parse on SystemMessage.Subtype in `internal/shared/message.go`. Add TaskUsage struct (total_tokens, tool_uses, duration_ms). TaskNotificationStatus enum: "completed", "failed", "stopped". |
+| 12 | #622 | list_sessions / get_session_messages | Mar 3 | feat | pending | - | Python added top-level list_sessions() and get_session_messages(session_id) using CLI flags --list-sessions and --get-session-messages. Returns []SDKSessionInfo and []SessionMessage. Add package-level functions, SDKSessionInfo struct (session_id, summary, last_modified, file_size, custom_title, first_prompt, git_branch, cwd), SessionMessage struct (type, uuid, session_id, message, parent_tool_use_id). Standalone CLI invocations, not control protocol. |
+| 13 | #628 | agent_id/agent_type in hook inputs | Mar 3 | feat | pending | - | Python added optional agent_id and agent_type to PreToolUseHookInput and PostToolUseHookInput via _SubagentContextMixin. Identifies which agent triggered tool use. Add `AgentID *string` and `AgentType *string` to both hook input structs in `internal/control/types_hook.go`. |
+| 14 | #630 | Fix string prompt closing stdin before MCP init | Mar 4 | fix | pending | - | Python fixed race: string prompt closed stdin before SDK MCP servers initialized. Check Go subprocess stdin in `internal/subprocess/` - verify stdin stays open until MCP init completes (wait for initialize response before closing write end). |
+| 14a | #642 | Wait for graceful subprocess shutdown before SIGTERM | Mar 19 | fix | pending | - | Python added a graceful wait period before sending SIGTERM, allowing the subprocess to finish in-flight work. Check Go process lifecycle in `internal/subprocess/process.go` - verify shutdown sequence gives process time to flush before SIGTERM. |
+| 15 | #648 | Typed RateLimitEvent message | Mar 12 | feat | pending | - | Python added dedicated RateLimitEvent message type (not SystemMessage) with RateLimitInfo: status, resets_at, rate_limit_type, utilization, overage_status, overage_resets_at, overage_disabled_reason, raw. Add RateLimitEvent struct implementing Message interface, RateLimitInfo struct, parser update to recognize type "rate_limit" in `internal/parser/parser.go`. Also carries uuid and session_id. |
+| 16 | #668 | rename_session | Mar 12 | feat | pending | - | Python added rename_session(session_id, new_name) to rename a session's custom title. Add RenameSession(ctx, sessionID, newName string) package-level function. Uses CLI flag or control request. |
+| 17 | #670 | tag_session with Unicode sanitization | Mar 12 | feat | pending | - | Python added tag_session(session_id, tag) with Unicode sanitization (strips non-printable chars, validates length). Add TagSession(ctx, sessionID, tag string) package-level function with equivalent Unicode validation. |
+| 18 | #685 | Preserve per-turn usage on AssistantMessage | Mar 16 | feat | pending | - | Python added `usage: dict` to AssistantMessage for per-turn token stats (input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens). Add `Usage map[string]any` with `json:"usage,omitempty"` to AssistantMessage in `internal/shared/message.go`. |
+| 19 | #684 | skills/memory/mcpServers on AgentDefinition | Mar 16 | feat | pending | - | Python added skills (list), memory (config), mcpServers (map) to AgentDefinition. Add `Skills []any`, `Memory any`, `McpServers map[string]McpServerConfig` with JSON tags to AgentDefinition in `internal/shared/options.go`. |
+| 20 | #686 | default-if-absent for CLAUDE_CODE_ENTRYPOINT | Mar 16 | fix | pending | - | Python only sets CLAUDE_CODE_ENTRYPOINT if not already in env (matching TS SDK). Check `internal/subprocess/config.go` - change from unconditional set to set-if-absent so users can override. |
+
+---
+
+## Phase 3 - Mar 20 to Mar 30
+
+| # | Py PR | Title | Merged | Cat | Go Status | Go PR | Notes |
+|:--|:------|:------|:-------|:----|:----------|:------|:------|
+| 21 | #667 | tag/created_at on SDKSessionInfo + get_session_info | Mar 20 | feat | pending | - | Python added tag and created_at fields to SDKSessionInfo. Added get_session_info(session_id) function. Add `Tag *string`, `CreatedAt *string` to SDKSessionInfo. Add GetSessionInfo(ctx, sessionID) package-level function. |
+| 22 | #591 | SystemPromptFile support | Mar 25 | feat | pending | - | Python added SystemPromptFile TypedDict passing --system-prompt-file to CLI. Add SystemPromptFile struct (Path string), update system_prompt option handling, add --system-prompt-file flag in `internal/cli/command.go`. |
+| 23 | #717 | propagate is_error from SDK MCP tool results | Mar 25 | fix | pending | - | Python fixed is_error flag propagation from McpToolResult to CLI. Check `internal/control/mcp.go` - verify IsError on McpToolResult is included in JSON response to CLI. |
+| 24 | #718 | Preserve dropped fields on AssistantMessage/ResultMessage | Mar 25 | feat | pending | - | Python captures unknown JSON fields into `extra_fields: dict` catch-all to prevent data loss when CLI adds new fields. Add `ExtraFields map[string]any` to AssistantMessage and ResultMessage, populated during UnmarshalJSON by collecting keys not in known fields. Forward-compatibility pattern. |
+| 25 | #719 | add missing dontAsk permission mode | Mar 25 | fix | pending | - | Python added "dontAsk" to PermissionMode (was missing despite being valid CLI mode). Add `PermissionModeDontAsk PermissionMode = "dontAsk"`. Check if Go SDK already has this. |
+| 26 | #720 | remove duplicate version warning | Mar 25 | fix | pending | - | Python removed duplicate CLI version warning. Check `internal/cli/version.go` - verify warning fires only once per session. |
+| 27 | #723 | skip non-JSON lines on CLI stdout | Mar 25 | fix | pending | - | Python skips non-JSON debug lines on stdout (DEBUG env in Docker/Lambda). Check `internal/parser/parser.go` - verify graceful skip of lines not starting with `{`. May already be handled by speculative parsing. |
+| 28 | #725 | handle resource_link/embedded resource in SDK MCP | Mar 25 | fix | pending | - | Python added resource_link and embedded_resource content types in SDK MCP tool responses. Check `mcp.go` - add support for these content types in McpContent or pass through as-is. |
+| 29 | #731 | remove stdin timeout for hooks/SDK MCP | Mar 25 | fix | pending | - | Python removed write timeout on stdin for hook/MCP responses (can take long). Check `internal/subprocess/io.go` - verify no artificial timeout on control response writes. |
+| 30 | #729 | SIGKILL fallback when SIGTERM blocks | Mar 26 | fix | pending | - | Python added SIGKILL escalation when SIGTERM handler blocks. Go SDK has SIGTERM->wait->SIGKILL in `internal/subprocess/process.go` - verify wait timeout (5s) and SIGKILL fires if process doesn't exit. |
+| 31 | #732 | filter CLAUDECODE env var from subprocess | Mar 26 | fix | pending | - | Python filters CLAUDECODE env var from subprocess to prevent child CLI inheritance. Check `internal/subprocess/config.go` - add CLAUDECODE to filtered env vars. |
+| 32 | #744 | fork_session, delete_session, offset pagination | Mar 26 | feat | pending | - | Python added fork_session(session_id) -> ForkSessionResult (new_session_id), delete_session(session_id), offset/limit params on list_sessions(). Add ForkSession(), DeleteSession() functions, ForkSessionResult struct, update ListSessions with pagination. |
+| 33 | #747 | task_budget option | Mar 26 | feat | pending | - | Python added TaskBudget TypedDict (total int) and task_budget option. Passed as --task-budget CLI flag. Add TaskBudget struct, WithTaskBudget() in `options.go`, CLI flag in `internal/cli/`. |
+| 34 | #743 | pass initialize_timeout from env var | Mar 26 | fix | pending | - | Python reads CLAUDE_CODE_STREAM_CLOSE_TIMEOUT env var to override initialize timeout. Check if Go SDK respects this, add support if not. |
+| 35 | #749 | errors field on ResultMessage | Mar 27 | fix | pending | - | Python added `errors: list[str]` to ResultMessage for non-fatal session errors. Add `Errors []string` with `json:"errors,omitempty"` to ResultMessage. Distinct from IsError (fatal failure flag). |
+| 36 | #759 | disallowedTools/maxTurns/initialPrompt on AgentDefinition | Mar 27 | feat | pending | - | Python added disallowedTools ([]string), maxTurns (int), initialPrompt (string) to AgentDefinition. Add `DisallowedTools []string`, `MaxTurns *int`, `InitialPrompt *string` with JSON tags to AgentDefinition. |
+| 37 | #750 | session_id on ClaudeAgentOptions | Mar 28 | feat | pending | - | Python added session_id option for custom session IDs. Passed as --session-id CLI flag. Add WithSessionID(id string) option, `SessionID *string` to Options, CLI flag in `internal/cli/`. |
+| 38 | #754 | tool_use_id/agent_id in ToolPermissionContext | Mar 28 | feat | pending | - | Python added tool_use_id and agent_id to ToolPermissionContext for richer permission callback context. Add `ToolUseID string` and `AgentID string` to ToolPermissionContext in `internal/control/types.go`. |
+| 39 | #764 | get_context_usage() | Mar 28 | feat | pending | - | Python added get_context_usage() returning ContextUsageResponse: categories ([]ContextUsageCategory with name/tokens/color/isDeferred), totalTokens, maxTokens, percentage, model, optional autoCompactThreshold/mcpTools/agents. Add GetContextUsage(ctx) to Client, ContextUsageResponse/ContextUsageCategory structs, control request subtype, wire through Transport. |
+| 40 | #751 | control_cancel_request handling | Mar 28 | feat | pending | - | Python handles control_cancel_request from CLI to cancel pending control requests (e.g., timed-out permission callbacks). Update `internal/control/protocol.go` to handle incoming "cancel_request" by canceling context of pending request by request_id. |
+| 41 | #769 | send string prompt in connect() | Mar 28 | fix | pending | - | Python fixed connect(prompt="...") silently dropping prompt. Verify Go Client.Connect() sends prompt via stdin after connection established. |
+| 42 | #778 | omit --setting-sources when empty | Mar 30 | fix | pending | - | Python omits --setting-sources when empty instead of passing empty value. Check `internal/cli/command.go` - verify empty SettingSources doesn't produce `--setting-sources ""`. |
+| 43 | #780 | background task for string prompts with hooks/MCP | Mar 30 | fix | pending | - | Python fixed deadlock with string prompt + hooks/MCP by spawning stdin write as background task. Verify Go SDK has no deadlock when hooks/MCP configured with string prompt. |
+
+---
+
+## Phase 4 - Mar 31 to Apr 8
+
+| # | Py PR | Title | Merged | Cat | Go Status | Go PR | Notes |
+|:--|:------|:------|:-------|:----|:----------|:------|:------|
+| 44 | #782 | background/effort/permissionMode on AgentDefinition | Mar 31 | feat | pending | - | Python added background (bool), effort (string), permissionMode (PermissionMode) to AgentDefinition. Add `Background *bool`, `Effort *string`, `PermissionMode *PermissionMode` with JSON tags. |
+| 45 | #756 | forward maxResultSizeChars via _meta | Apr 2 | fix | pending | - | Python forwards maxResultSizeChars in _meta of MCP tool results for large results (>50K chars). Add _meta.maxResultSizeChars to tool result JSON when exceeding threshold. |
+| 46 | #785 | 'auto' PermissionMode | Apr 7 | feat | pending | - | Python added "auto" PermissionMode (auto-approves safe tools, prompts for dangerous). Add `PermissionModeAuto PermissionMode = "auto"` in `internal/shared/options.go`. |
+| 47 | #796 | --thinking flag for adaptive/disabled | Apr 7 | fix | pending | - | Python fixed CLI flags: adaptive -> `--thinking adaptive`, disabled -> `--thinking disabled` (not budget tokens). Update CLI builder in `internal/cli/command.go` to handle ThinkingConfig types correctly. |
+| 48 | #797 | exclude_dynamic_sections on SystemPromptPreset | Apr 8 | feat | pending | - | Python added exclude_dynamic_sections bool to SystemPromptPreset for cross-user prompt caching. Add ExcludeDynamicSections bool to SystemPromptPreset struct (create if needed), pass as CLI flag. |
+
+---
 
 ## Skipped PRs
 
@@ -141,7 +138,7 @@ Not applicable to Go SDK. Listed for completeness so nothing falls through crack
 | #746 | Resolve cross-task cancel scope RuntimeError | Mar 26 | Python async/anyio specific |
 | #760 | Increase test-examples timeout | Mar 28 | CI timeout |
 | #761 | typing_extensions.TypedDict on Python 3.10 | Mar 27 | Python 3.10 compat |
-| #762 | Annotated for per-parameter descriptions in @tool | Mar 28 | Python typing.Annotated feature |
+| #762 | Annotated for per-parameter descriptions in @tool | Mar 28 | Python typing.Annotated specific |
 
 ---
 
@@ -150,6 +147,4 @@ Not applicable to Go SDK. Listed for completeness so nothing falls through crack
 1. **Starting work:** Set Go Status to `in-progress` for the current row
 2. **PR merged:** Set Go Status to `done`, fill Go PR column with `#N`
 3. **Not applicable:** Set Go Status to `skip`, add reason in Notes
-4. **New Python PRs (after April 12, 2026):** Append rows to the replay queue in merge order, update snapshot date
-5. **Keep summary stats in sync** with the table counts
-6. **Re-evaluate priorities** as replay progresses - some P2s may become P0 based on user reports
+4. **New Python PRs (after April 12, 2026):** Append rows to Phase 4 (or create Phase 5) in merge order, update snapshot date

--- a/docs/tracking/README.md
+++ b/docs/tracking/README.md
@@ -1,6 +1,6 @@
 # Python SDK PR Replay Tracker
 
-Tracks all Python SDK PRs that need to be replayed into the Go SDK to restore parity.
+Tracks all Python SDK PRs that need to be replayed into the Go SDK to restore parity. PRs are listed in merge-order - replay them top to bottom.
 
 ## Snapshot
 
@@ -22,184 +22,127 @@ PRs merged after April 12, 2026 are NOT tracked here. Add them manually and upda
 | P0 | 8 | Message types/parsing - broken deserialization if missing |
 | P1 | 25 | New client methods, options, control protocol features |
 | P2 | 15 | Bug fixes - evaluate Go applicability |
-| Skip | 16+ | CI/CD, Python typing, async-specific, PyPI/wheel, CLI bumps |
+| Skip | 24 | CI/CD, Python typing, async-specific, PyPI/wheel, CLI bumps |
 | **Actionable** | **48** | |
 
 ## Priority Scale
 
-- **P0 (Critical):** New fields or types on messages. Missing these means the Go SDK silently drops data from CLI responses or fails to deserialize. Must be done first.
+- **P0 (Critical):** New fields or types on messages. Missing these means the Go SDK silently drops data from CLI responses or fails to deserialize.
 - **P1 (High):** New client methods, configuration options, or control protocol features. The SDK works without these but lacks functionality the Python SDK offers.
 - **P2 (Medium):** Bug fixes from the Python SDK. Each must be evaluated against the Go codebase - some may already be handled differently, some may need porting.
 - **Skip:** Not applicable to Go SDK. CI/CD workflows, Python-specific typing (typing_extensions, TypedDict compat, Annotated), Python async-specific fixes (cancel scope, event loop), PyPI/wheel publishing, CLI version bumps, docs-only changes.
 
-## Implementation Waves
+## Implementation Waves (Reference)
 
-### Wave 1 - Type Safety (P0)
+Waves group related PRs by area. Use as a reference when working on a PR to see what else touches the same files.
 
-PRs: #506, #598, #619, #621, #648, #685, #718, #749
-
-Scope: Add missing fields to ResultMessage (stop_reason, errors), AssistantMessage (usage, error fix, dropped fields). Add RateLimitEvent message type. Add typed TaskStarted/TaskProgress/TaskNotification subtypes. Handle unknown message types gracefully.
-
-Go files: `internal/shared/message.go`, `internal/parser/parser.go`
-
-### Wave 2 - Hook System
-
-PRs: #535, #545, #628
-
-Scope: Add PostToolUseFailure hook event. Add Notification, SubagentStart, PermissionRequest hook events. Add agent_id/agent_type fields to tool-lifecycle hook inputs.
-
-Go files: `internal/control/types_hook.go`, `internal/control/hooks.go`
-
-### Wave 3 - Session Management
-
-PRs: #622, #667, #668, #670, #744, #750
-
-Scope: Add list_sessions(), get_session_info(), get_session_messages(), rename_session(), tag_session(), fork_session(), delete_session() functions. Add offset pagination. Add session_id option. Add tag/created_at to SDKSessionInfo.
-
-Go files: `client.go`, `options.go`, `internal/control/`
-
-### Wave 4 - Agent/Options
-
-PRs: #468, #565, #591, #684, #747, #759, #782, #785, #796, #797
-
-Scope: Send agent definitions via initialize request (not CLI flag). Add ThinkingConfig types + effort option. Add SystemPromptFile support. Expand AgentDefinition with skills, memory, mcpServers, disallowedTools, maxTurns, initialPrompt, background, effort, permissionMode. Add task_budget option. Add 'auto' PermissionMode. Fix --thinking flag construction. Add exclude_dynamic_sections on SystemPromptPreset.
-
-Go files: `internal/shared/options.go`, `options.go`, `internal/cli/command.go`
-
-### Wave 5 - MCP Enhancements
-
-PRs: #516, #551, #620
-
-Scope: Add get_mcp_status() method. Add MCP tool annotations. Add reconnect_mcp_server() and toggle_mcp_server() methods with typed McpServerStatus.
-
-Go files: `mcp.go`, `client.go`, `internal/control/`
-
-### Wave 6 - New Client Methods
-
-PRs: #751, #754, #764
-
-Scope: Handle control_cancel_request from CLI. Add tool_use_id/agent_id to ToolPermissionContext. Add get_context_usage() method.
-
-Go files: `client.go`, `internal/control/types.go`, `transport.go`
-
-### Wave 7 - Bug Fix Audit
-
-PRs: #630, #686, #717, #719, #720, #723, #725, #729, #731, #732, #743, #756, #769, #778, #780
-
-Scope: Evaluate each fix against Go codebase. Key items: dontAsk permission mode (#719), skip non-JSON stdout lines (#723), SIGKILL fallback (#729), filter CLAUDECODE env var (#732), string prompt fixes (#769, #780).
-
-Go files: various - each fix evaluated independently
+| Wave | Area | PRs | Go Files |
+|:-----|:-----|:----|:---------|
+| 1 | Type Safety (P0) | #506, #598, #619, #621, #648, #685, #718, #749 | `internal/shared/message.go`, `internal/parser/parser.go` |
+| 2 | Hook System | #535, #545, #628 | `internal/control/types_hook.go`, `internal/control/hooks.go` |
+| 3 | Session Management | #622, #667, #668, #670, #744, #750 | `client.go`, `options.go`, `internal/control/` |
+| 4 | Agent/Options | #468, #565, #591, #684, #747, #759, #782, #785, #796, #797 | `internal/shared/options.go`, `options.go`, `internal/cli/command.go` |
+| 5 | MCP Enhancements | #516, #551, #620 | `mcp.go`, `client.go`, `internal/control/` |
+| 6 | New Client Methods | #751, #754, #764 | `client.go`, `internal/control/types.go`, `transport.go` |
+| 7 | Bug Fix Audit | #630, #686, #717, #719, #720, #723, #725, #729, #731, #732, #743, #756, #769, #778, #780 | various |
 
 ---
 
-## Tracking Table
+## Replay Queue (Chronological)
 
-### Already Ported
+Replay in order. Each row is one Python SDK PR, sorted by merge date.
 
-| Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
-|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
-| #495 | tool_use_result on UserMessage | Jan 23 | feat | - | - | done | #99 | Added ToolUseResult map[string]any field to UserMessage with HasToolUseResult()/GetToolUseResult() helpers |
+| # | Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
+|:--|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
+| - | #495 | tool_use_result on UserMessage | Jan 23 | feat | - | - | done | #99 | Added ToolUseResult map[string]any field to UserMessage with HasToolUseResult()/GetToolUseResult() helpers |
+| 1 | #516 | get_mcp_status() method | Jan 26 | feat | P1 | 5 | pending | - | Python added get_mcp_status() returning McpStatusResponse with list of McpServerStatus (name, status, serverInfo, error, config, scope, tools). Add GetMcpStatus(ctx) to Client interface, control request subtype "get_mcp_status", McpServerStatus/McpStatusResponse types in `internal/control/types.go`, wire through Transport. |
+| 2 | #535 | PostToolUseFailure hook event | Jan 30 | feat | P1 | 2 | pending | - | Python added "PostToolUseFailure" hook event firing when tool execution fails (distinct from PostToolUse on success). Add `HookEventPostToolUseFailure = "PostToolUseFailure"` constant, PostToolUseFailureHookInput (embeds BaseHookInput, has ToolName, ToolInput, Error), PostToolUseFailureHookSpecificOutput in `internal/control/types_hook.go`. |
+| 3 | #506 | Properly populate AssistantMessage error field | Feb 3 | fix | P0 | 1 | pending | - | Python fixed AssistantMessage.error not being populated from JSON during deserialization. Go SDK has AssistantMessage.Error *AssistantMessageError - verify UnmarshalJSON in `internal/shared/message.go` correctly parses the `error` object with type/message fields. Test with rate_limit, billing_error, server_error payloads. |
+| 4 | #545 | Missing hook events + fix fields | Feb 3 | feat | P1 | 2 | pending | - | Python added 3 hook events: "Notification" (system notifications), "SubagentStart" (subagent spawned), "PermissionRequest" (permission requested). Each has HookInput type. Also fixed existing hook fields. Add 3 HookEvent constants, 3 HookInput structs, 3 HookSpecificOutput structs in `internal/control/types_hook.go`. Add SubagentContextMixin equivalent (AgentID, AgentType *string) to relevant inputs. |
+| 5 | #551 | MCP tool annotations | Feb 5 | feat | P1 | 5 | pending | - | Python added McpToolAnnotations (readOnly, destructive, openWorld bools) and McpToolInfo (name, description, annotations). Returned in MCP server status and tool listings. Add structs in `mcp.go` or `internal/shared/options.go`. Wire into McpServerStatus.Tools. |
+| 6 | #468 | Send agent definitions via initialize request | Feb 5 | feat | P1 | 4 | pending | - | Python sends agents in initialize control request instead of --agents CLI flag. Add `Agents map[string]AgentDefinition` to InitializeRequest in `internal/control/types.go`. Update `internal/control/protocol.go` to include agents. Remove/deprecate --agents flag in `internal/cli/`. |
+| 7 | #565 | ThinkingConfig types and effort option | Feb 11 | feat | P1 | 4 | pending | - | Python replaced max_thinking_tokens with ThinkingConfig union: ThinkingConfigAdaptive (type="adaptive"), ThinkingConfigEnabled (type="enabled", budget_tokens), ThinkingConfigDisabled (type="disabled"). Added effort option ("low"/"medium"/"high"/"max"). Add ThinkingConfig interface + 3 structs, WithThinking(), WithEffort() in `options.go`. Update CLI flags: adaptive -> `--thinking adaptive`, disabled -> `--thinking disabled`, enabled -> `--thinking-budget N`. Deprecate WithMaxThinkingTokens(). |
+| 8 | #598 | Handle unknown message types gracefully | Feb 20 | fix | P0 | 1 | pending | - | Python returns a raw/passthrough message instead of crashing on unrecognized `type` field. Go SDK parser in `internal/parser/parser.go` likely returns error on unknown types. Change to return RawMessage or fallback type so new CLI message types don't break existing consumers. Forward-compatibility. |
+| 9 | #619 | stop_reason on ResultMessage | Mar 3 | feat | P0 | 1 | pending | - | Python added `stop_reason: str` to ResultMessage (values: "end_turn", "max_tokens", "stop_sequence"). Add `StopReason string` field with `json:"stop_reason"` to ResultMessage in `internal/shared/message.go`. Wire through UnmarshalJSON. |
+| 10 | #620 | MCP control methods + typed McpServerStatus | Mar 3 | feat | P1 | 5 | pending | - | Python added reconnect_mcp_server(name) and toggle_mcp_server(name, enabled). Also typed McpServerStatus with McpServerConnectionStatus enum ("connected"/"failed"/"needs-auth"/"pending"/"disabled") and McpServerInfo (name, version). Add ReconnectMcpServer(ctx, name) and ToggleMcpServer(ctx, name, enabled) on Client interface, new control request subtypes, wire through Transport. |
+| 11 | #621 | Typed TaskStarted/TaskProgress/TaskNotification | Mar 3 | feat | P0 | 1 | pending | - | Python created typed SystemMessage subclasses: TaskStartedMessage (task_id, prompt), TaskProgressMessage (task_id, tool_name, progress), TaskNotificationMessage (task_id, status, usage). Go SDK uses generic SystemMessage with Data map. Add concrete structs for each subtype, parse on SystemMessage.Subtype in `internal/shared/message.go`. Add TaskUsage struct (total_tokens, tool_uses, duration_ms). TaskNotificationStatus enum: "completed", "failed", "stopped". |
+| 12 | #622 | list_sessions / get_session_messages | Mar 3 | feat | P1 | 3 | pending | - | Python added top-level list_sessions() and get_session_messages(session_id) using CLI flags --list-sessions and --get-session-messages. Returns []SDKSessionInfo and []SessionMessage. Add package-level functions, SDKSessionInfo struct (session_id, summary, last_modified, file_size, custom_title, first_prompt, git_branch, cwd), SessionMessage struct (type, uuid, session_id, message, parent_tool_use_id). Standalone CLI invocations, not control protocol. |
+| 13 | #628 | agent_id/agent_type in hook inputs | Mar 3 | feat | P1 | 2 | pending | - | Python added optional agent_id and agent_type to PreToolUseHookInput and PostToolUseHookInput via _SubagentContextMixin. Identifies which agent triggered tool use. Add `AgentID *string` and `AgentType *string` to both hook input structs in `internal/control/types_hook.go`. |
+| 14 | #630 | Fix string prompt closing stdin before MCP init | Mar 4 | fix | P2 | 7 | pending | - | Python fixed race: string prompt closed stdin before SDK MCP servers initialized. Check Go subprocess stdin in `internal/subprocess/` - verify stdin stays open until MCP init completes (wait for initialize response before closing write end). |
+| 15 | #648 | Typed RateLimitEvent message | Mar 12 | feat | P0 | 1 | pending | - | Python added dedicated RateLimitEvent message type (not SystemMessage) with RateLimitInfo: status, resets_at, rate_limit_type, utilization, overage_status, overage_resets_at, overage_disabled_reason, raw. Add RateLimitEvent struct implementing Message interface, RateLimitInfo struct, parser update to recognize type "rate_limit" in `internal/parser/parser.go`. Also carries uuid and session_id. |
+| 16 | #668 | rename_session | Mar 12 | feat | P1 | 3 | pending | - | Python added rename_session(session_id, new_name) to rename a session's custom title. Add RenameSession(ctx, sessionID, newName string) package-level function. Uses CLI flag or control request. |
+| 17 | #670 | tag_session with Unicode sanitization | Mar 12 | feat | P1 | 3 | pending | - | Python added tag_session(session_id, tag) with Unicode sanitization (strips non-printable chars, validates length). Add TagSession(ctx, sessionID, tag string) package-level function with equivalent Unicode validation. |
+| 18 | #685 | Preserve per-turn usage on AssistantMessage | Mar 16 | feat | P0 | 1 | pending | - | Python added `usage: dict` to AssistantMessage for per-turn token stats (input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens). Add `Usage map[string]any` with `json:"usage,omitempty"` to AssistantMessage in `internal/shared/message.go`. |
+| 19 | #684 | skills/memory/mcpServers on AgentDefinition | Mar 16 | feat | P1 | 4 | pending | - | Python added skills (list), memory (config), mcpServers (map) to AgentDefinition. Add `Skills []any`, `Memory any`, `McpServers map[string]McpServerConfig` with JSON tags to AgentDefinition in `internal/shared/options.go`. |
+| 20 | #686 | default-if-absent for CLAUDE_CODE_ENTRYPOINT | Mar 16 | fix | P2 | 7 | pending | - | Python only sets CLAUDE_CODE_ENTRYPOINT if not already in env (matching TS SDK). Check `internal/subprocess/config.go` - change from unconditional set to set-if-absent so users can override. |
+| 21 | #667 | tag/created_at on SDKSessionInfo + get_session_info | Mar 20 | feat | P1 | 3 | pending | - | Python added tag and created_at fields to SDKSessionInfo. Added get_session_info(session_id) function. Add `Tag *string`, `CreatedAt *string` to SDKSessionInfo. Add GetSessionInfo(ctx, sessionID) package-level function. |
+| 22 | #591 | SystemPromptFile support | Mar 25 | feat | P1 | 4 | pending | - | Python added SystemPromptFile TypedDict passing --system-prompt-file to CLI. Add SystemPromptFile struct (Path string), update system_prompt option handling, add --system-prompt-file flag in `internal/cli/command.go`. |
+| 23 | #717 | propagate is_error from SDK MCP tool results | Mar 25 | fix | P2 | 7 | pending | - | Python fixed is_error flag propagation from McpToolResult to CLI. Check `internal/control/mcp.go` - verify IsError on McpToolResult is included in JSON response to CLI. |
+| 24 | #718 | Preserve dropped fields on AssistantMessage/ResultMessage | Mar 25 | feat | P0 | 1 | pending | - | Python captures unknown JSON fields into `extra_fields: dict` catch-all to prevent data loss when CLI adds new fields. Add `ExtraFields map[string]any` to AssistantMessage and ResultMessage, populated during UnmarshalJSON by collecting keys not in known fields. Forward-compatibility pattern. |
+| 25 | #719 | add missing dontAsk permission mode | Mar 25 | fix | P2 | 7 | pending | - | Python added "dontAsk" to PermissionMode (was missing despite being valid CLI mode). Add `PermissionModeDontAsk PermissionMode = "dontAsk"`. Check if Go SDK already has this. |
+| 26 | #720 | remove duplicate version warning | Mar 25 | fix | P2 | 7 | pending | - | Python removed duplicate CLI version warning. Check `internal/cli/version.go` - verify warning fires only once per session. |
+| 27 | #723 | skip non-JSON lines on CLI stdout | Mar 25 | fix | P2 | 7 | pending | - | Python skips non-JSON debug lines on stdout (DEBUG env in Docker/Lambda). Check `internal/parser/parser.go` - verify graceful skip of lines not starting with `{`. May already be handled by speculative parsing. |
+| 28 | #725 | handle resource_link/embedded resource in SDK MCP | Mar 25 | fix | P2 | 7 | pending | - | Python added resource_link and embedded_resource content types in SDK MCP tool responses. Check `mcp.go` - add support for these content types in McpContent or pass through as-is. |
+| 29 | #731 | remove stdin timeout for hooks/SDK MCP | Mar 25 | fix | P2 | 7 | pending | - | Python removed write timeout on stdin for hook/MCP responses (can take long). Check `internal/subprocess/io.go` - verify no artificial timeout on control response writes. |
+| 30 | #729 | SIGKILL fallback when SIGTERM blocks | Mar 26 | fix | P2 | 7 | pending | - | Python added SIGKILL escalation when SIGTERM handler blocks. Go SDK has SIGTERM->wait->SIGKILL in `internal/subprocess/process.go` - verify wait timeout (5s) and SIGKILL fires if process doesn't exit. |
+| 31 | #732 | filter CLAUDECODE env var from subprocess | Mar 26 | fix | P2 | 7 | pending | - | Python filters CLAUDECODE env var from subprocess to prevent child CLI inheritance. Check `internal/subprocess/config.go` - add CLAUDECODE to filtered env vars. |
+| 32 | #744 | fork_session, delete_session, offset pagination | Mar 26 | feat | P1 | 3 | pending | - | Python added fork_session(session_id) -> ForkSessionResult (new_session_id), delete_session(session_id), offset/limit params on list_sessions(). Add ForkSession(), DeleteSession() functions, ForkSessionResult struct, update ListSessions with pagination. |
+| 33 | #747 | task_budget option | Mar 26 | feat | P1 | 4 | pending | - | Python added TaskBudget TypedDict (total int) and task_budget option. Passed as --task-budget CLI flag. Add TaskBudget struct, WithTaskBudget() in `options.go`, CLI flag in `internal/cli/`. |
+| 34 | #743 | pass initialize_timeout from env var | Mar 26 | fix | P2 | 7 | pending | - | Python reads CLAUDE_CODE_STREAM_CLOSE_TIMEOUT env var to override initialize timeout. Check if Go SDK respects this, add support if not. |
+| 35 | #749 | errors field on ResultMessage | Mar 27 | fix | P0 | 1 | pending | - | Python added `errors: list[str]` to ResultMessage for non-fatal session errors. Add `Errors []string` with `json:"errors,omitempty"` to ResultMessage. Distinct from IsError (fatal failure flag). |
+| 36 | #759 | disallowedTools/maxTurns/initialPrompt on AgentDefinition | Mar 27 | feat | P1 | 4 | pending | - | Python added disallowedTools ([]string), maxTurns (int), initialPrompt (string) to AgentDefinition. Add `DisallowedTools []string`, `MaxTurns *int`, `InitialPrompt *string` with JSON tags to AgentDefinition. |
+| 37 | #750 | session_id on ClaudeAgentOptions | Mar 28 | feat | P1 | 3 | pending | - | Python added session_id option for custom session IDs. Passed as --session-id CLI flag. Add WithSessionID(id string) option, `SessionID *string` to Options, CLI flag in `internal/cli/`. |
+| 38 | #754 | tool_use_id/agent_id in ToolPermissionContext | Mar 28 | feat | P1 | 6 | pending | - | Python added tool_use_id and agent_id to ToolPermissionContext for richer permission callback context. Add `ToolUseID string` and `AgentID string` to ToolPermissionContext in `internal/control/types.go`. |
+| 39 | #764 | get_context_usage() | Mar 28 | feat | P1 | 6 | pending | - | Python added get_context_usage() returning ContextUsageResponse: categories ([]ContextUsageCategory with name/tokens/color/isDeferred), totalTokens, maxTokens, percentage, model, optional autoCompactThreshold/mcpTools/agents. Add GetContextUsage(ctx) to Client, ContextUsageResponse/ContextUsageCategory structs, control request subtype, wire through Transport. |
+| 40 | #751 | control_cancel_request handling | Mar 28 | feat | P1 | 6 | pending | - | Python handles control_cancel_request from CLI to cancel pending control requests (e.g., timed-out permission callbacks). Update `internal/control/protocol.go` to handle incoming "cancel_request" by canceling context of pending request by request_id. |
+| 41 | #769 | send string prompt in connect() | Mar 28 | fix | P2 | 7 | pending | - | Python fixed connect(prompt="...") silently dropping prompt. Verify Go Client.Connect() sends prompt via stdin after connection established. |
+| 42 | #778 | omit --setting-sources when empty | Mar 30 | fix | P2 | 7 | pending | - | Python omits --setting-sources when empty instead of passing empty value. Check `internal/cli/command.go` - verify empty SettingSources doesn't produce `--setting-sources ""`. |
+| 43 | #780 | background task for string prompts with hooks/MCP | Mar 30 | fix | P2 | 7 | pending | - | Python fixed deadlock with string prompt + hooks/MCP by spawning stdin write as background task. Verify Go SDK has no deadlock when hooks/MCP configured with string prompt. |
+| 44 | #782 | background/effort/permissionMode on AgentDefinition | Mar 31 | feat | P1 | 4 | pending | - | Python added background (bool), effort (string), permissionMode (PermissionMode) to AgentDefinition. Add `Background *bool`, `Effort *string`, `PermissionMode *PermissionMode` with JSON tags. |
+| 45 | #756 | forward maxResultSizeChars via _meta | Apr 2 | fix | P2 | 7 | pending | - | Python forwards maxResultSizeChars in _meta of MCP tool results for large results (>50K chars). Add _meta.maxResultSizeChars to tool result JSON when exceeding threshold. |
+| 46 | #785 | 'auto' PermissionMode | Apr 7 | feat | P1 | 4 | pending | - | Python added "auto" PermissionMode (auto-approves safe tools, prompts for dangerous). Add `PermissionModeAuto PermissionMode = "auto"` in `internal/shared/options.go`. |
+| 47 | #796 | --thinking flag for adaptive/disabled | Apr 7 | fix | P1 | 4 | pending | - | Python fixed CLI flags: adaptive -> `--thinking adaptive`, disabled -> `--thinking disabled` (not budget tokens). Update CLI builder in `internal/cli/command.go` to handle ThinkingConfig types correctly. |
+| 48 | #797 | exclude_dynamic_sections on SystemPromptPreset | Apr 8 | feat | P1 | 4 | pending | - | Python added exclude_dynamic_sections bool to SystemPromptPreset for cross-user prompt caching. Add ExcludeDynamicSections bool to SystemPromptPreset struct (create if needed), pass as CLI flag. |
 
-### P0 - Critical
+## Skipped PRs
 
-| Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
-|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
-| #506 | Properly populate AssistantMessage error field | Feb 3 | fix | P0 | 1 | pending | - | Python fixed AssistantMessage.error not being populated from JSON during deserialization. Go SDK has AssistantMessage.Error *AssistantMessageError - verify UnmarshalJSON in `internal/shared/message.go` correctly parses the `error` object with type/message fields. Test with rate_limit, billing_error, server_error payloads. |
-| #598 | Handle unknown message types gracefully | Feb 20 | fix | P0 | 1 | pending | - | Python returns a raw/passthrough message instead of crashing on unrecognized `type` field. Go SDK parser in `internal/parser/parser.go` likely returns error on unknown types. Change to return RawMessage or fallback type so new CLI message types don't break existing consumers. Forward-compatibility. |
-| #619 | stop_reason on ResultMessage | Mar 3 | feat | P0 | 1 | pending | - | Python added `stop_reason: str` to ResultMessage (values: "end_turn", "max_tokens", "stop_sequence"). Add `StopReason string` field with `json:"stop_reason"` to ResultMessage in `internal/shared/message.go`. Wire through UnmarshalJSON. |
-| #621 | Typed TaskStarted/TaskProgress/TaskNotification | Mar 3 | feat | P0 | 1 | pending | - | Python created typed SystemMessage subclasses: TaskStartedMessage (task_id, prompt), TaskProgressMessage (task_id, tool_name, progress), TaskNotificationMessage (task_id, status, usage). Go SDK uses generic SystemMessage with Data map. Add concrete structs for each subtype, parse on SystemMessage.Subtype in `internal/shared/message.go`. Add TaskUsage struct (total_tokens, tool_uses, duration_ms). TaskNotificationStatus enum: "completed", "failed", "stopped". |
-| #648 | Typed RateLimitEvent message | Mar 12 | feat | P0 | 1 | pending | - | Python added dedicated RateLimitEvent message type (not SystemMessage) with RateLimitInfo: status, resets_at, rate_limit_type, utilization, overage_status, overage_resets_at, overage_disabled_reason, raw. Add RateLimitEvent struct implementing Message interface, RateLimitInfo struct, parser update to recognize type "rate_limit" in `internal/parser/parser.go`. Also carries uuid and session_id. |
-| #685 | Preserve per-turn usage on AssistantMessage | Mar 16 | feat | P0 | 1 | pending | - | Python added `usage: dict` to AssistantMessage for per-turn token stats (input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens). Add `Usage map[string]any` with `json:"usage,omitempty"` to AssistantMessage in `internal/shared/message.go`. |
-| #718 | Preserve dropped fields on AssistantMessage/ResultMessage | Mar 25 | feat | P0 | 1 | pending | - | Python captures unknown JSON fields into `extra_fields: dict` catch-all to prevent data loss when CLI adds new fields. Add `ExtraFields map[string]any` to AssistantMessage and ResultMessage, populated during UnmarshalJSON by collecting keys not in known fields. Forward-compatibility pattern. |
-| #749 | errors field on ResultMessage | Mar 27 | fix | P0 | 1 | pending | - | Python added `errors: list[str]` to ResultMessage for non-fatal session errors. Add `Errors []string` with `json:"errors,omitempty"` to ResultMessage. Distinct from IsError (fatal failure flag). |
+Not applicable to Go SDK. Listed for completeness so nothing falls through cracks.
 
-### P1 - High
-
-| Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
-|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
-| #516 | get_mcp_status() method | Jan 26 | feat | P1 | 5 | pending | - | Python added get_mcp_status() returning McpStatusResponse with list of McpServerStatus (name, status, serverInfo, error, config, scope, tools). Add GetMcpStatus(ctx) to Client interface, control request subtype "get_mcp_status", McpServerStatus/McpStatusResponse types in `internal/control/types.go`, wire through Transport. |
-| #535 | PostToolUseFailure hook event | Jan 30 | feat | P1 | 2 | pending | - | Python added "PostToolUseFailure" hook event firing when tool execution fails (distinct from PostToolUse on success). Add `HookEventPostToolUseFailure = "PostToolUseFailure"` constant, PostToolUseFailureHookInput (embeds BaseHookInput, has ToolName, ToolInput, Error), PostToolUseFailureHookSpecificOutput in `internal/control/types_hook.go`. |
-| #545 | Missing hook events + fix fields | Feb 3 | feat | P1 | 2 | pending | - | Python added 3 hook events: "Notification" (system notifications), "SubagentStart" (subagent spawned), "PermissionRequest" (permission requested). Each has HookInput type. Also fixed existing hook fields. Add 3 HookEvent constants, 3 HookInput structs, 3 HookSpecificOutput structs in `internal/control/types_hook.go`. Add SubagentContextMixin equivalent (AgentID, AgentType *string) to relevant inputs. |
-| #551 | MCP tool annotations | Feb 5 | feat | P1 | 5 | pending | - | Python added McpToolAnnotations (readOnly, destructive, openWorld bools) and McpToolInfo (name, description, annotations). Returned in MCP server status and tool listings. Add structs in `mcp.go` or `internal/shared/options.go`. Wire into McpServerStatus.Tools. |
-| #468 | Send agent definitions via initialize request | Feb 5 | feat | P1 | 4 | pending | - | Python sends agents in initialize control request instead of --agents CLI flag. Add `Agents map[string]AgentDefinition` to InitializeRequest in `internal/control/types.go`. Update `internal/control/protocol.go` to include agents. Remove/deprecate --agents flag in `internal/cli/`. |
-| #565 | ThinkingConfig types and effort option | Feb 11 | feat | P1 | 4 | pending | - | Python replaced max_thinking_tokens with ThinkingConfig union: ThinkingConfigAdaptive (type="adaptive"), ThinkingConfigEnabled (type="enabled", budget_tokens), ThinkingConfigDisabled (type="disabled"). Added effort option ("low"/"medium"/"high"/"max"). Add ThinkingConfig interface + 3 structs, WithThinking(), WithEffort() in `options.go`. Update CLI flags: adaptive -> `--thinking adaptive`, disabled -> `--thinking disabled`, enabled -> `--thinking-budget N`. Deprecate WithMaxThinkingTokens(). |
-| #622 | list_sessions / get_session_messages | Mar 3 | feat | P1 | 3 | pending | - | Python added top-level list_sessions() and get_session_messages(session_id) using CLI flags --list-sessions and --get-session-messages. Returns []SDKSessionInfo and []SessionMessage. Add package-level functions, SDKSessionInfo struct (session_id, summary, last_modified, file_size, custom_title, first_prompt, git_branch, cwd), SessionMessage struct (type, uuid, session_id, message, parent_tool_use_id). Standalone CLI invocations, not control protocol. |
-| #628 | agent_id/agent_type in hook inputs | Mar 3 | feat | P1 | 2 | pending | - | Python added optional agent_id and agent_type to PreToolUseHookInput and PostToolUseHookInput via _SubagentContextMixin. Identifies which agent triggered tool use. Add `AgentID *string` and `AgentType *string` to both hook input structs in `internal/control/types_hook.go`. |
-| #648 | Typed RateLimitEvent message | Mar 12 | feat | P0 | 1 | pending | - | (tracked in P0 section above) |
-| #668 | rename_session | Mar 12 | feat | P1 | 3 | pending | - | Python added rename_session(session_id, new_name) to rename a session's custom title. Add RenameSession(ctx, sessionID, newName string) package-level function. Uses CLI flag or control request. |
-| #670 | tag_session with Unicode sanitization | Mar 12 | feat | P1 | 3 | pending | - | Python added tag_session(session_id, tag) with Unicode sanitization (strips non-printable chars, validates length). Add TagSession(ctx, sessionID, tag string) package-level function with equivalent Unicode validation. |
-| #684 | skills/memory/mcpServers on AgentDefinition | Mar 16 | feat | P1 | 4 | pending | - | Python added skills (list), memory (config), mcpServers (map) to AgentDefinition. Add `Skills []any`, `Memory any`, `McpServers map[string]McpServerConfig` with JSON tags to AgentDefinition in `internal/shared/options.go`. |
-| #667 | tag/created_at on SDKSessionInfo + get_session_info | Mar 20 | feat | P1 | 3 | pending | - | Python added tag and created_at fields to SDKSessionInfo. Added get_session_info(session_id) function. Add `Tag *string`, `CreatedAt *string` to SDKSessionInfo. Add GetSessionInfo(ctx, sessionID) package-level function. |
-| #591 | SystemPromptFile support | Mar 25 | feat | P1 | 4 | pending | - | Python added SystemPromptFile TypedDict passing --system-prompt-file to CLI. Add SystemPromptFile struct (Path string), update system_prompt option handling, add --system-prompt-file flag in `internal/cli/command.go`. |
-| #744 | fork_session, delete_session, offset pagination | Mar 26 | feat | P1 | 3 | pending | - | Python added fork_session(session_id) -> ForkSessionResult (new_session_id), delete_session(session_id), offset/limit params on list_sessions(). Add ForkSession(), DeleteSession() functions, ForkSessionResult struct, update ListSessions with pagination. |
-| #747 | task_budget option | Mar 26 | feat | P1 | 4 | pending | - | Python added TaskBudget TypedDict (total int) and task_budget option. Passed as --task-budget CLI flag. Add TaskBudget struct, WithTaskBudget() in `options.go`, CLI flag in `internal/cli/`. |
-| #759 | disallowedTools/maxTurns/initialPrompt on AgentDefinition | Mar 27 | feat | P1 | 4 | pending | - | Python added disallowedTools ([]string), maxTurns (int), initialPrompt (string) to AgentDefinition. Add `DisallowedTools []string`, `MaxTurns *int`, `InitialPrompt *string` with JSON tags to AgentDefinition. |
-| #750 | session_id on ClaudeAgentOptions | Mar 28 | feat | P1 | 3 | pending | - | Python added session_id option for custom session IDs. Passed as --session-id CLI flag. Add WithSessionID(id string) option, `SessionID *string` to Options, CLI flag in `internal/cli/`. |
-| #751 | control_cancel_request handling | Mar 28 | feat | P1 | 6 | pending | - | Python handles control_cancel_request from CLI to cancel pending control requests (e.g., timed-out permission callbacks). Update `internal/control/protocol.go` to handle incoming "cancel_request" by canceling context of pending request by request_id. |
-| #754 | tool_use_id/agent_id in ToolPermissionContext | Mar 28 | feat | P1 | 6 | pending | - | Python added tool_use_id and agent_id to ToolPermissionContext for richer permission callback context. Add `ToolUseID string` and `AgentID string` to ToolPermissionContext in `internal/control/types.go`. |
-| #764 | get_context_usage() | Mar 28 | feat | P1 | 6 | pending | - | Python added get_context_usage() returning ContextUsageResponse: categories ([]ContextUsageCategory with name/tokens/color/isDeferred), totalTokens, maxTokens, percentage, model, optional autoCompactThreshold/mcpTools/agents. Add GetContextUsage(ctx) to Client, ContextUsageResponse/ContextUsageCategory structs, control request subtype, wire through Transport. |
-| #782 | background/effort/permissionMode on AgentDefinition | Mar 31 | feat | P1 | 4 | pending | - | Python added background (bool), effort (string), permissionMode (PermissionMode) to AgentDefinition. Add `Background *bool`, `Effort *string`, `PermissionMode *PermissionMode` with JSON tags. |
-| #785 | 'auto' PermissionMode | Apr 7 | feat | P1 | 4 | pending | - | Python added "auto" PermissionMode (auto-approves safe tools, prompts for dangerous). Add `PermissionModeAuto PermissionMode = "auto"` in `internal/shared/options.go`. |
-| #796 | --thinking flag for adaptive/disabled | Apr 7 | fix | P1 | 4 | pending | - | Python fixed CLI flags: adaptive -> `--thinking adaptive`, disabled -> `--thinking disabled` (not budget tokens). Update CLI builder in `internal/cli/command.go` to handle ThinkingConfig types correctly. |
-| #797 | exclude_dynamic_sections on SystemPromptPreset | Apr 8 | feat | P1 | 4 | pending | - | Python added exclude_dynamic_sections bool to SystemPromptPreset for cross-user prompt caching. Add ExcludeDynamicSections bool to SystemPromptPreset struct (create if needed), pass as CLI flag. |
-
-### P2 - Medium (Bug Fixes)
-
-| Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
-|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
-| #630 | Fix string prompt closing stdin before MCP init | Mar 4 | fix | P2 | 7 | pending | - | Python fixed race: string prompt closed stdin before SDK MCP servers initialized. Check Go subprocess stdin in `internal/subprocess/` - verify stdin stays open until MCP init completes (wait for initialize response before closing write end). |
-| #686 | default-if-absent for CLAUDE_CODE_ENTRYPOINT | Mar 16 | fix | P2 | 7 | pending | - | Python only sets CLAUDE_CODE_ENTRYPOINT if not already in env (matching TS SDK). Check `internal/subprocess/config.go` - change from unconditional set to set-if-absent so users can override. |
-| #717 | propagate is_error from SDK MCP tool results | Mar 25 | fix | P2 | 7 | pending | - | Python fixed is_error flag propagation from McpToolResult to CLI. Check `internal/control/mcp.go` - verify IsError on McpToolResult is included in JSON response to CLI. |
-| #719 | add missing dontAsk permission mode | Mar 25 | fix | P2 | 7 | pending | - | Python added "dontAsk" to PermissionMode (was missing despite being valid CLI mode). Add `PermissionModeDontAsk PermissionMode = "dontAsk"`. Check if Go SDK already has this. |
-| #720 | remove duplicate version warning | Mar 25 | fix | P2 | 7 | pending | - | Python removed duplicate CLI version warning. Check `internal/cli/version.go` - verify warning fires only once per session. |
-| #723 | skip non-JSON lines on CLI stdout | Mar 25 | fix | P2 | 7 | pending | - | Python skips non-JSON debug lines on stdout (DEBUG env in Docker/Lambda). Check `internal/parser/parser.go` - verify graceful skip of lines not starting with `{`. May already be handled by speculative parsing. |
-| #725 | handle resource_link/embedded resource in SDK MCP | Mar 25 | fix | P2 | 7 | pending | - | Python added resource_link and embedded_resource content types in SDK MCP tool responses. Check `mcp.go` - add support for these content types in McpContent or pass through as-is. |
-| #729 | SIGKILL fallback when SIGTERM blocks | Mar 26 | fix | P2 | 7 | pending | - | Python added SIGKILL escalation when SIGTERM handler blocks. Go SDK has SIGTERM->wait->SIGKILL in `internal/subprocess/process.go` - verify wait timeout (5s) and SIGKILL fires if process doesn't exit. |
-| #731 | remove stdin timeout for hooks/SDK MCP | Mar 25 | fix | P2 | 7 | pending | - | Python removed write timeout on stdin for hook/MCP responses (can take long). Check `internal/subprocess/io.go` - verify no artificial timeout on control response writes. |
-| #732 | filter CLAUDECODE env var from subprocess | Mar 26 | fix | P2 | 7 | pending | - | Python filters CLAUDECODE env var from subprocess to prevent child CLI inheritance. Check `internal/subprocess/config.go` - add CLAUDECODE to filtered env vars. |
-| #743 | pass initialize_timeout from env var | Mar 26 | fix | P2 | 7 | pending | - | Python reads CLAUDE_CODE_STREAM_CLOSE_TIMEOUT env var to override initialize timeout. Check if Go SDK respects this, add support if not. |
-| #756 | forward maxResultSizeChars via _meta | Apr 2 | fix | P2 | 7 | pending | - | Python forwards maxResultSizeChars in _meta of MCP tool results for large results (>50K chars). Add _meta.maxResultSizeChars to tool result JSON when exceeding threshold. |
-| #769 | send string prompt in connect() | Mar 28 | fix | P2 | 7 | pending | - | Python fixed connect(prompt="...") silently dropping prompt. Verify Go Client.Connect() sends prompt via stdin after connection established. |
-| #778 | omit --setting-sources when empty | Mar 30 | fix | P2 | 7 | pending | - | Python omits --setting-sources when empty instead of passing empty value. Check `internal/cli/command.go` - verify empty SettingSources doesn't produce `--setting-sources ""`. |
-| #780 | background task for string prompts with hooks/MCP | Mar 30 | fix | P2 | 7 | pending | - | Python fixed deadlock with string prompt + hooks/MCP by spawning stdin write as background task. Verify Go SDK has no deadlock when hooks/MCP configured with string prompt. |
-
-### Skip
-
-| Py PR | Title | Merged | Cat | Pri | Wave | Go Status | Go PR | Notes |
-|:------|:------|:-------|:----|:----|:-----|:----------|:------|:------|
-| #451 | Skip jobs requiring secrets from forks | Jan 5 | ci | skip | - | skip | - | CI workflow |
-| #467 | Update claude-code actions to @v1 | Jan 12 | ci | skip | - | skip | - | CI workflow |
-| #485 | Make permission callback e2e test robust | Jan 16 | test | skip | - | skip | - | Python e2e test |
-| #486 | Release v0.1.20 | Jan 16 | chore | skip | - | skip | - | Python release |
-| #488 | Extract build-and-publish workflow | Jan 21 | ci | skip | - | skip | - | CI workflow |
-| #503 | Release v0.1.21 | Jan 21 | chore | skip | - | skip | - | Python release |
-| #504 | Fix release job permissions | Jan 22 | ci | skip | - | skip | - | CI workflow |
-| #511 | Fix SSH remote URL in auto-release | Jan 23 | ci | skip | - | skip | - | CI workflow |
-| #512 | Release v0.1.22 | Jan 23 | chore | skip | - | skip | - | Python release |
-| #536 | Add debug output to MCP e2e tests | Jan 30 | test | skip | - | skip | - | Python test |
-| #537 | Pin CI to Python 3.13 | Jan 30 | ci | skip | - | skip | - | CI workflow |
-| #538 | Enforce sequential tool execution in MCP e2e | Jan 30 | test | skip | - | skip | - | Python test |
-| #539 | Simplify release flow + RELEASING.md | Jan 30 | ci | skip | - | skip | - | CI workflow |
-| #556 | Update Claude model to opus-4-6 in CI | Feb 7 | ci | skip | - | skip | - | CI workflow |
-| #661 | Publish macOS x86_64 wheel | Mar 9 | ci | skip | - | skip | - | Python wheel |
-| #662 | Upload check wheels as artifacts | Mar 12 | ci | skip | - | skip | - | Python wheel |
-| #700 | Harden PyPI publish | Mar 20 | ci | skip | - | skip | - | PyPI infra |
-| #705 | Daily PyPI storage quota monitoring | Mar 20 | ci | skip | - | skip | - | PyPI infra |
-| #708 | Retry install.sh fetch on 429 | Mar 24 | ci | skip | - | skip | - | Build infra |
-| #722 | Defer CLI discovery to connect() | Mar 25 | fix | skip | - | skip | - | Python async event loop specific |
-| #736 | Convert TypedDict input_schema to JSON Schema | Mar 26 | fix | skip | - | skip | - | Python TypedDict specific |
-| #746 | Resolve cross-task cancel scope RuntimeError | Mar 26 | fix | skip | - | skip | - | Python async/anyio specific |
-| #760 | Increase test-examples timeout | Mar 28 | ci | skip | - | skip | - | CI timeout |
-| #761 | typing_extensions.TypedDict on Python 3.10 | Mar 27 | fix | skip | - | skip | - | Python 3.10 compat |
-| #762 | Annotated for per-parameter descriptions in @tool | Mar 28 | feat | skip | - | skip | - | Python typing.Annotated feature |
+| Py PR | Title | Merged | Reason |
+|:------|:------|:-------|:-------|
+| #451 | Skip jobs requiring secrets from forks | Jan 5 | CI workflow |
+| #467 | Update claude-code actions to @v1 | Jan 12 | CI workflow |
+| #485 | Make permission callback e2e test robust | Jan 16 | Python e2e test |
+| #486 | Release v0.1.20 | Jan 16 | Python release |
+| #488 | Extract build-and-publish workflow | Jan 21 | CI workflow |
+| #503 | Release v0.1.21 | Jan 21 | Python release |
+| #504 | Fix release job permissions | Jan 22 | CI workflow |
+| #511 | Fix SSH remote URL in auto-release | Jan 23 | CI workflow |
+| #512 | Release v0.1.22 | Jan 23 | Python release |
+| #536 | Add debug output to MCP e2e tests | Jan 30 | Python test |
+| #537 | Pin CI to Python 3.13 | Jan 30 | CI workflow |
+| #538 | Enforce sequential tool execution in MCP e2e | Jan 30 | Python test |
+| #539 | Simplify release flow + RELEASING.md | Jan 30 | CI workflow |
+| #556 | Update Claude model to opus-4-6 in CI | Feb 7 | CI workflow |
+| #661 | Publish macOS x86_64 wheel | Mar 9 | Python wheel |
+| #662 | Upload check wheels as artifacts | Mar 12 | Python wheel |
+| #700 | Harden PyPI publish | Mar 20 | PyPI infra |
+| #705 | Daily PyPI storage quota monitoring | Mar 20 | PyPI infra |
+| #708 | Retry install.sh fetch on 429 | Mar 24 | Build infra |
+| #722 | Defer CLI discovery to connect() | Mar 25 | Python async event loop specific |
+| #736 | Convert TypedDict input_schema to JSON Schema | Mar 26 | Python TypedDict specific |
+| #746 | Resolve cross-task cancel scope RuntimeError | Mar 26 | Python async/anyio specific |
+| #760 | Increase test-examples timeout | Mar 28 | CI timeout |
+| #761 | typing_extensions.TypedDict on Python 3.10 | Mar 27 | Python 3.10 compat |
+| #762 | Annotated for per-parameter descriptions in @tool | Mar 28 | Python typing.Annotated feature |
 
 ---
 
 ## How to Update
 
-1. **Starting work:** Set Go Status to `in-progress`
+1. **Starting work:** Set Go Status to `in-progress` for the current row
 2. **PR merged:** Set Go Status to `done`, fill Go PR column with `#N`
 3. **Not applicable:** Set Go Status to `skip`, add reason in Notes
-4. **New Python PRs (after April 12, 2026):** Add rows to the table, update snapshot date
+4. **New Python PRs (after April 12, 2026):** Append rows to the replay queue in merge order, update snapshot date
 5. **Keep summary stats in sync** with the table counts
-6. **Re-evaluate priorities** as waves complete - some P2s may become P0 based on user reports
+6. **Re-evaluate priorities** as replay progresses - some P2s may become P0 based on user reports


### PR DESCRIPTION
## Summary

- Created `docs/tracking/README.md` - a living tracker of 48 actionable Python SDK PRs (8 P0, 25 P1, 15 P2) merged between Jan 6 and Apr 12, 2026 that need replaying into the Go SDK to restore parity
- PRs organized into 7 implementation waves with actionable context per entry
- Updated `/tdd` command to sync Python SDK main before work, reference the tracker, and update tracker status after merge
- Updated `/qualify` command to fix stale Python SDK path, pull main before cross-referencing, and check tracker for PR mappings

## Context

Go SDK parity work peaked Jan 6, 2026 (Go PR #77). Last ported feature was Go PR #99 (Jan 24 - tool_use_result). Since then the Python SDK shipped 36 releases (v0.1.22 -> v0.1.58) with ~50 PRs we haven't caught up with. This tracker gives us a systematic way to replay those changes.

## Test plan

- [ ] Verify `docs/tracking/README.md` renders correctly on GitHub
- [ ] Verify `/tdd` command references tracker and pulls Python SDK
- [ ] Verify `/qualify` command uses correct Python SDK path