### PR TITLE
Allow MaxBufferSize to be configured by the implementer

### DIFF
--- a/internal/parser/json.go
+++ b/internal/parser/json.go
@@ -30,6 +30,13 @@ func New() *Parser {
 	}
 }
 
+// NewWithSize creates a new JSON parser with a custom maximum buffer size.
+func NewWithSize(maxBufferSize int) *Parser {
+	return &Parser{
+		maxBufferSize: maxBufferSize,
+	}
+}
+
 // ProcessLine processes a line of JSON input with speculative parsing.
 // Handles multiple JSON objects on single line and embedded newlines.
 func (p *Parser) ProcessLine(line string) ([]shared.Message, error) {

--- a/internal/subprocess/io.go
+++ b/internal/subprocess/io.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/severity1/claude-agent-sdk-go/internal/parser"
 	"github.com/severity1/claude-agent-sdk-go/internal/shared"
 )
 
@@ -18,13 +19,14 @@ func (t *Transport) handleStdout() {
 
 	scanner := bufio.NewScanner(t.stdout)
 
-	// Increase scanner buffer to handle large tool results (files, etc.)
-	// Default bufio.Scanner has MaxScanTokenSize of 64KB which is insufficient
-	// for tool results containing large files. We use 1MB to match parser's
-	// MaxBufferSize and handle files up to ~900KB after JSON encoding overhead.
-	const maxScanTokenSize = 1024 * 1024 // 1MB
-	buf := make([]byte, maxScanTokenSize)
-	scanner.Buffer(buf, maxScanTokenSize)
+	// Scanner token size must match the parser's buffer limit so lines aren't
+	// truncated before parsing. Default is 64KB; respect MaxBufferSize if set.
+	scanTokenSize := parser.MaxBufferSize
+	if t.options != nil && t.options.MaxBufferSize != nil {
+		scanTokenSize = *t.options.MaxBufferSize
+	}
+	buf := make([]byte, scanTokenSize)
+	scanner.Buffer(buf, scanTokenSize)
 
 	for scanner.Scan() {
 		select {

--- a/internal/subprocess/transport.go
+++ b/internal/subprocess/transport.go
@@ -77,7 +77,7 @@ func New(cliPath string, options *shared.Options, closeStdin bool, entrypoint st
 		options:    options,
 		closeStdin: closeStdin,
 		entrypoint: entrypoint,
-		parser:     parser.New(),
+		parser:     newParser(options),
 		validator:  shared.NewStreamValidator(),
 	}
 }
@@ -89,10 +89,18 @@ func NewWithPrompt(cliPath string, options *shared.Options, prompt string) *Tran
 		options:    options,
 		closeStdin: true,
 		entrypoint: "sdk-go", // Query mode uses sdk-go
-		parser:     parser.New(),
+		parser:     newParser(options),
 		validator:  shared.NewStreamValidator(),
 		promptArg:  &prompt,
 	}
+}
+
+// newParser creates a parser using the buffer size from options, or the default.
+func newParser(options *shared.Options) *parser.Parser {
+	if options != nil && options.MaxBufferSize != nil {
+		return parser.NewWithSize(*options.MaxBufferSize)
+	}
+	return parser.New()
 }
 
 // IsConnected returns whether the transport is currently connected.


### PR DESCRIPTION
Use the already existing option MaxBufferSize to allow implementers to configure it for the parser and scanner