### PR TITLE
feat: Add alwaysLoad to MCP server configs (Issue #119)

### DIFF
--- a/internal/shared/options.go
+++ b/internal/shared/options.go
@@ -279,6 +279,10 @@ type McpStdioServerConfig struct {
 	Command string            `json:"command"`
 	Args    []string          `json:"args,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`
+	// AlwaysLoad, when true, opts the server out of tool-search deferral so
+	// all of its tools are always available without a ToolSearch round-trip.
+	// Requires Claude Code CLI 2.1.121 or later.
+	AlwaysLoad bool `json:"alwaysLoad,omitempty"`
 }
 
 // GetType returns the server type for McpStdioServerConfig.
@@ -291,6 +295,10 @@ type McpSSEServerConfig struct {
 	Type    McpServerType     `json:"type"`
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
+	// AlwaysLoad, when true, opts the server out of tool-search deferral so
+	// all of its tools are always available without a ToolSearch round-trip.
+	// Requires Claude Code CLI 2.1.121 or later.
+	AlwaysLoad bool `json:"alwaysLoad,omitempty"`
 }
 
 // GetType returns the server type for McpSSEServerConfig.
@@ -303,6 +311,10 @@ type McpHTTPServerConfig struct {
 	Type    McpServerType     `json:"type"`
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
+	// AlwaysLoad, when true, opts the server out of tool-search deferral so
+	// all of its tools are always available without a ToolSearch round-trip.
+	// Requires Claude Code CLI 2.1.121 or later.
+	AlwaysLoad bool `json:"alwaysLoad,omitempty"`
 }
 
 // GetType returns the server type for McpHTTPServerConfig.
@@ -333,6 +345,10 @@ type McpSdkServerConfig struct {
 	Type     McpServerType `json:"type"`
 	Name     string        `json:"name"`
 	Instance McpServer     `json:"-"` // Excluded from CLI serialization
+	// AlwaysLoad, when true, opts the server out of tool-search deferral so
+	// all of its tools are always available without a ToolSearch round-trip.
+	// Requires Claude Code CLI 2.1.121 or later.
+	AlwaysLoad bool `json:"alwaysLoad,omitempty"`
 }
 
 // GetType returns the server type for McpSdkServerConfig.

--- a/internal/shared/options_test.go
+++ b/internal/shared/options_test.go
@@ -1,6 +1,8 @@
 package shared
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -163,6 +165,112 @@ func TestMcpServerTypes(t *testing.T) {
 			assertMcpServerType(t, test.config, test.expectedType)
 		})
 	}
+}
+
+// TestMcpServerConfigAlwaysLoad verifies that AlwaysLoad is wired through all
+// four MCP server config structs and round-trips through JSON correctly.
+// A false (default) value must be omitted from the marshaled output thanks to
+// the omitempty tag, so the CLI sees only servers that have explicitly opted in.
+func TestMcpServerConfigAlwaysLoad(t *testing.T) {
+	t.Run("defaults_to_false", func(t *testing.T) {
+		stdio := &McpStdioServerConfig{Type: McpServerTypeStdio, Command: "node"}
+		sse := &McpSSEServerConfig{Type: McpServerTypeSSE, URL: "https://example.com/sse"}
+		http := &McpHTTPServerConfig{Type: McpServerTypeHTTP, URL: "https://example.com/http"}
+		sdk := &McpSdkServerConfig{Type: McpServerTypeSdk, Name: "test"}
+		if stdio.AlwaysLoad || sse.AlwaysLoad || http.AlwaysLoad || sdk.AlwaysLoad {
+			t.Error("AlwaysLoad should default to false on all MCP server config types")
+		}
+	})
+
+	tests := []struct {
+		name   string
+		config McpServerConfig
+	}{
+		{
+			name: "stdio",
+			config: &McpStdioServerConfig{
+				Type:       McpServerTypeStdio,
+				Command:    "node",
+				Args:       []string{"server.js"},
+				AlwaysLoad: true,
+			},
+		},
+		{
+			name: "sse",
+			config: &McpSSEServerConfig{
+				Type:       McpServerTypeSSE,
+				URL:        "https://example.com/sse",
+				AlwaysLoad: true,
+			},
+		},
+		{
+			name: "http",
+			config: &McpHTTPServerConfig{
+				Type:       McpServerTypeHTTP,
+				URL:        "https://example.com/http",
+				AlwaysLoad: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+"_marshals_alwaysLoad_when_true", func(t *testing.T) {
+			data, err := json.Marshal(test.config)
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			if !strings.Contains(string(data), `"alwaysLoad":true`) {
+				t.Errorf("Expected JSON to contain alwaysLoad:true, got %s", data)
+			}
+		})
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+"_omits_alwaysLoad_when_false", func(t *testing.T) {
+			// Construct a copy with AlwaysLoad cleared.
+			var data []byte
+			var err error
+			switch c := test.config.(type) {
+			case *McpStdioServerConfig:
+				dup := *c
+				dup.AlwaysLoad = false
+				data, err = json.Marshal(&dup)
+			case *McpSSEServerConfig:
+				dup := *c
+				dup.AlwaysLoad = false
+				data, err = json.Marshal(&dup)
+			case *McpHTTPServerConfig:
+				dup := *c
+				dup.AlwaysLoad = false
+				data, err = json.Marshal(&dup)
+			}
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			if strings.Contains(string(data), "alwaysLoad") {
+				t.Errorf("Expected alwaysLoad to be omitted when false, got %s", data)
+			}
+		})
+	}
+
+	t.Run("stdio_round_trip", func(t *testing.T) {
+		original := &McpStdioServerConfig{
+			Type:       McpServerTypeStdio,
+			Command:    "node",
+			AlwaysLoad: true,
+		}
+		data, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal failed: %v", err)
+		}
+		var decoded McpStdioServerConfig
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal failed: %v", err)
+		}
+		if !decoded.AlwaysLoad {
+			t.Error("AlwaysLoad lost in round-trip")
+		}
+	})
 }
 
 // TestPermissionModeConstants tests permission mode constant values

--- a/internal/subprocess/config.go
+++ b/internal/subprocess/config.go
@@ -19,11 +19,17 @@ func (t *Transport) generateMcpConfigFile() (string, error) {
 	serversForCLI := make(map[string]any)
 	for name, config := range t.options.McpServers {
 		if sdkConfig, ok := config.(*shared.McpSdkServerConfig); ok {
-			// SDK servers: only send type and name to CLI
-			serversForCLI[name] = map[string]any{
+			// SDK servers: only send type and name to CLI (the Go Instance
+			// stays in-process). AlwaysLoad must be propagated explicitly
+			// since we're not relying on struct json tags here.
+			entry := map[string]any{
 				"type": string(sdkConfig.Type),
 				"name": sdkConfig.Name,
 			}
+			if sdkConfig.AlwaysLoad {
+				entry["alwaysLoad"] = true
+			}
+			serversForCLI[name] = entry
 		} else {
 			// External servers: pass as-is
 			serversForCLI[name] = config

--- a/internal/subprocess/config_test.go
+++ b/internal/subprocess/config_test.go
@@ -341,6 +341,95 @@ func TestTransportMcpServerConfiguration(t *testing.T) {
 			},
 		},
 		{
+			name: "stdio_alwaysLoad_propagates_to_config_file",
+			setup: func() *Transport {
+				mcpServers := map[string]shared.McpServerConfig{
+					"always-loaded": &shared.McpStdioServerConfig{
+						Type:       shared.McpServerTypeStdio,
+						Command:    "node",
+						AlwaysLoad: true,
+					},
+					"deferred": &shared.McpStdioServerConfig{
+						Type:    shared.McpServerTypeStdio,
+						Command: "node",
+					},
+				}
+				options := &shared.Options{McpServers: mcpServers}
+				return New(newTransportMockCLI(), options, false, "sdk-go")
+			},
+			validate: func(t *testing.T, transport *Transport) {
+				t.Helper()
+				if transport.mcpConfigFile == nil {
+					t.Fatal("Expected MCP config file to be generated")
+				}
+				configData, err := os.ReadFile(transport.mcpConfigFile.Name())
+				if err != nil {
+					t.Fatalf("Failed to read MCP config file: %v", err)
+				}
+				var config map[string]interface{}
+				if err := json.Unmarshal(configData, &config); err != nil {
+					t.Fatalf("MCP config is not valid JSON: %v", err)
+				}
+				servers := config["mcpServers"].(map[string]interface{})
+
+				always := servers["always-loaded"].(map[string]interface{})
+				if always["alwaysLoad"] != true {
+					t.Errorf("Expected alwaysLoad=true on always-loaded server, got %v", always["alwaysLoad"])
+				}
+
+				deferred := servers["deferred"].(map[string]interface{})
+				if _, present := deferred["alwaysLoad"]; present {
+					t.Errorf("Expected alwaysLoad to be omitted when false, got %v", deferred["alwaysLoad"])
+				}
+			},
+		},
+		{
+			name: "sdk_alwaysLoad_propagates_to_config_file",
+			setup: func() *Transport {
+				mcpServers := map[string]shared.McpServerConfig{
+					"sdk-server": &shared.McpSdkServerConfig{
+						Type:       shared.McpServerTypeSdk,
+						Name:       "sdk-server",
+						AlwaysLoad: true,
+					},
+					"sdk-deferred": &shared.McpSdkServerConfig{
+						Type: shared.McpServerTypeSdk,
+						Name: "sdk-deferred",
+					},
+				}
+				options := &shared.Options{McpServers: mcpServers}
+				return New(newTransportMockCLI(), options, false, "sdk-go")
+			},
+			validate: func(t *testing.T, transport *Transport) {
+				t.Helper()
+				if transport.mcpConfigFile == nil {
+					t.Fatal("Expected MCP config file to be generated")
+				}
+				configData, err := os.ReadFile(transport.mcpConfigFile.Name())
+				if err != nil {
+					t.Fatalf("Failed to read MCP config file: %v", err)
+				}
+				var config map[string]interface{}
+				if err := json.Unmarshal(configData, &config); err != nil {
+					t.Fatalf("MCP config is not valid JSON: %v", err)
+				}
+				servers := config["mcpServers"].(map[string]interface{})
+
+				always := servers["sdk-server"].(map[string]interface{})
+				if always["alwaysLoad"] != true {
+					t.Errorf("Expected alwaysLoad=true on sdk-server, got %v", always["alwaysLoad"])
+				}
+				if always["type"] != string(shared.McpServerTypeSdk) {
+					t.Errorf("Expected type=%q, got %v", shared.McpServerTypeSdk, always["type"])
+				}
+
+				deferred := servers["sdk-deferred"].(map[string]interface{})
+				if _, present := deferred["alwaysLoad"]; present {
+					t.Errorf("Expected alwaysLoad to be omitted when false, got %v", deferred["alwaysLoad"])
+				}
+			},
+		},
+		{
 			name: "mcp_config_added_to_extra_args",
 			setup: func() *Transport {
 				mcpServers := map[string]shared.McpServerConfig{


### PR DESCRIPTION
## Summary

Adds support for the `alwaysLoad` MCP server option introduced in Claude Code CLI 2.1.121:

> Added `alwaysLoad` option to MCP server config — when `true`, all tools from that server skip tool-search deferral and are always available.

This is useful for in-process SDK MCP servers whose tools are central to every turn — consumers can opt them out of deferral and avoid an extra `ToolSearch` round-trip for every cold tool use.

Closes #119.

## Changes

- **`internal/shared/options.go`** — adds `AlwaysLoad bool` with `json:"alwaysLoad,omitempty"` to all four MCP server config structs (`McpStdioServerConfig`, `McpSSEServerConfig`, `McpHTTPServerConfig`, `McpSdkServerConfig`). Mirrors the existing optional-bool pattern used in `SandboxSettings`/`SandboxNetworkConfig`.
- **`internal/subprocess/config.go`** — `generateMcpConfigFile` builds a hand-crafted map for SDK servers (because `Instance` is non-serializable). Updated to propagate `alwaysLoad` explicitly when set, since the struct json tags aren't used on that branch. External servers (stdio / SSE / HTTP) flow through `json.Marshal` and pick up the new tag automatically.

## Tests

- `internal/shared/options_test.go` — new `TestMcpServerConfigAlwaysLoad`:
  - default-false on all four structs
  - `alwaysLoad:true` is present in marshaled JSON for stdio/SSE/HTTP when set
  - `alwaysLoad` is omitted from JSON when false (omitempty regression guard)
  - round-trip `Marshal` → `Unmarshal` preserves the value
- `internal/subprocess/config_test.go` — two new cases in `TestTransportMcpServerConfiguration`:
  - `stdio_alwaysLoad_propagates_to_config_file` — verifies the generated MCP config file contains `alwaysLoad:true` for opted-in servers and omits it for non-opted servers
  - `sdk_alwaysLoad_propagates_to_config_file` — same, but exercises the explicit-map path for SDK servers (regression guard against the strip-down logic)

## Verification

```
go build ./...
go vet ./...
go test -race -cover ./...
```

All green. `internal/shared` coverage 96.0%, `internal/subprocess` 75.2% (unchanged from baseline).

`make check` flags a pre-existing `revive` warning on `internal/shared/errors*.go` (`avoid meaningless package names`) that also fails on `main` at d94a048 without these changes — not introduced here.