### PR TITLE
Preserve parent_tool_use_id on AssistantMessage

### DIFF
--- a/internal/parser/json.go
+++ b/internal/parser/json.go
@@ -251,10 +251,19 @@ func (p *Parser) parseAssistantMessage(data map[string]any) (*shared.AssistantMe
 		errorPtr = &errType
 	}
 
+	// parent_tool_use_id is set on assistant messages produced inside a subagent
+	// (Agent/Task tool). Lives at the top-level of the raw event, matching the
+	// Python SDK and the user-message parsing above.
+	var parentToolUseID *string
+	if ptid, ok := data["parent_tool_use_id"].(string); ok {
+		parentToolUseID = &ptid
+	}
+
 	return &shared.AssistantMessage{
-		Content: blocks,
-		Model:   model,
-		Error:   errorPtr,
+		Content:         blocks,
+		Model:           model,
+		Error:           errorPtr,
+		ParentToolUseID: parentToolUseID,
 	}, nil
 }
 

--- a/internal/parser/json_test.go
+++ b/internal/parser/json_test.go
@@ -123,6 +123,35 @@ func TestParseValidMessages(t *testing.T) {
 				},
 			},
 			expectedType: shared.MessageTypeAssistant,
+			validate: func(t *testing.T, msg shared.Message) {
+				t.Helper()
+				am := msg.(*shared.AssistantMessage)
+				if am.ParentToolUseID != nil {
+					t.Errorf("expected ParentToolUseID nil, got %v", am.ParentToolUseID)
+				}
+			},
+		},
+		{
+			name: "assistant_message_with_parent_tool_use_id",
+			data: map[string]any{
+				"type":               "assistant",
+				"parent_tool_use_id": "tool-abc",
+				"message": map[string]any{
+					"content": []any{map[string]any{"type": "text", "text": "Subagent reply"}},
+					"model":   "claude-3-sonnet",
+				},
+			},
+			expectedType: shared.MessageTypeAssistant,
+			validate: func(t *testing.T, msg shared.Message) {
+				t.Helper()
+				am := msg.(*shared.AssistantMessage)
+				if am.ParentToolUseID == nil || *am.ParentToolUseID != "tool-abc" {
+					t.Errorf("expected ParentToolUseID 'tool-abc', got %v", am.ParentToolUseID)
+				}
+				if am.GetParentToolUseID() != "tool-abc" {
+					t.Errorf("expected GetParentToolUseID() 'tool-abc', got %q", am.GetParentToolUseID())
+				}
+			},
 		},
 		// Issue #23: AssistantMessage error field tests
 		{

--- a/internal/shared/message.go
+++ b/internal/shared/message.go
@@ -105,15 +105,26 @@ func (m *UserMessage) MarshalJSON() ([]byte, error) {
 
 // AssistantMessage represents a message from the assistant.
 type AssistantMessage struct {
-	MessageType string                 `json:"type"`
-	Content     []ContentBlock         `json:"content"`
-	Model       string                 `json:"model"`
-	Error       *AssistantMessageError `json:"error,omitempty"`
+	MessageType     string                 `json:"type"`
+	Content         []ContentBlock         `json:"content"`
+	Model           string                 `json:"model"`
+	Error           *AssistantMessageError `json:"error,omitempty"`
+	ParentToolUseID *string                `json:"parent_tool_use_id,omitempty"`
 }
 
 // Type returns the message type for AssistantMessage.
 func (m *AssistantMessage) Type() string {
 	return MessageTypeAssistant
+}
+
+// GetParentToolUseID returns the parent tool use ID or empty string if nil.
+// Set by the CLI on assistant messages produced inside a subagent (Agent/Task tool)
+// to identify the orchestrator tool_use_id that spawned the subagent.
+func (m *AssistantMessage) GetParentToolUseID() string {
+	if m.ParentToolUseID != nil {
+		return *m.ParentToolUseID
+	}
+	return ""
 }
 
 // HasError returns true if the message contains an error.

--- a/internal/shared/message_test.go
+++ b/internal/shared/message_test.go
@@ -459,6 +459,56 @@ func TestUserMessageJSONMarshalingWithOptionalFields(t *testing.T) {
 	}
 }
 
+// TestAssistantMessageGetParentToolUseID tests the GetParentToolUseID helper method
+func TestAssistantMessageGetParentToolUseID(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       *string
+		expected string
+	}{
+		{"nil returns empty", nil, ""},
+		{"non-nil returns value", strPtr("tool-abc"), "tool-abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := &AssistantMessage{ParentToolUseID: tt.id}
+			if got := msg.GetParentToolUseID(); got != tt.expected {
+				t.Errorf("GetParentToolUseID() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestAssistantMessageJSONMarshalingWithParentToolUseID tests JSON marshaling of ParentToolUseID
+func TestAssistantMessageJSONMarshalingWithParentToolUseID(t *testing.T) {
+	parentToolUseID := "tool-abc"
+	asstMsg := &AssistantMessage{
+		Content:         []ContentBlock{},
+		Model:           "claude-3-sonnet",
+		ParentToolUseID: &parentToolUseID,
+	}
+
+	jsonData, err := json.Marshal(asstMsg)
+	if err != nil {
+		t.Fatalf("Failed to marshal AssistantMessage: %v", err)
+	}
+	assertJSONField(t, jsonData, "type", MessageTypeAssistant)
+	assertJSONField(t, jsonData, "parent_tool_use_id", "tool-abc")
+
+	asstMsgNoOptional := &AssistantMessage{Content: []ContentBlock{}, Model: "claude-3-sonnet"}
+	jsonDataNoOptional, err := json.Marshal(asstMsgNoOptional)
+	if err != nil {
+		t.Fatalf("Failed to marshal AssistantMessage: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(jsonDataNoOptional, &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+	if _, exists := result["parent_tool_use_id"]; exists {
+		t.Error("Expected 'parent_tool_use_id' field to be omitted when nil")
+	}
+}
+
 // strPtr is a helper to create a pointer to a string
 func strPtr(s string) *string {
 	return &s


### PR DESCRIPTION
## Summary

When the CLI delegates work via the Agent (Task) tool, every assistant message produced by the subagent carries a top-level `parent_tool_use_id` pointing back at the orchestrator's `tool_use_id`. The TypeScript SDK exposes this on `SDKAssistantMessage`, and this Go SDK already preserves it on `UserMessage` (`internal/shared/message.go:58`), `StreamEvent` (`internal/shared/stream.go:303`), and `StreamMessage` (`internal/shared/stream.go:9`). It is silently dropped on `AssistantMessage` — both the struct and `parseAssistantMessage` ignore the field.

This makes it impossible for consumers to associate a subagent's `ToolUseBlock` with the parent Agent call at the time the tool use is emitted. Without it, the only way to recover the linkage is to wait for the matching `ToolResultBlock` on the next `UserMessage` (which does carry `parent_tool_use_id`), which is too late for live UI feedback.

## Changes

- `internal/shared/message.go` — add `ParentToolUseID *string` field (with `omitempty`) to `AssistantMessage`, plus a `GetParentToolUseID()` helper mirroring the `UserMessage` API.
- `internal/parser/json.go` — extract `parent_tool_use_id` from the top-level event in `parseAssistantMessage`, matching how `parseUserMessage` and `parseStreamEventMessage` already do it.
- `internal/parser/json_test.go` — add cases for assistant messages with and without `parent_tool_use_id`.
- `internal/shared/message_test.go` — add helper-method test and JSON marshal round-trip test (asserts `omitempty` when nil).

## Backwards compatibility

Additive only. The new field is `*string` with `omitempty`, so existing callers and existing serialized payloads are unaffected. `MarshalJSON` already uses an embedded alias struct, so the field round-trips automatically.

## Verification

- `go build ./...` green
- `go test ./...` green (all packages pass, including `internal/shared`, `internal/parser`, `internal/cli`, `internal/control`, `internal/subprocess`)

## Reference

- TypeScript SDK exposes the same field on `SDKAssistantMessage`: https://code.claude.com/docs/en/agent-sdk/typescript#agent-2
- Existing parity in this repo: `UserMessage.ParentToolUseID`, `StreamEvent.ParentToolUseID`, `StreamMessage.ParentToolUseID`