### PR TITLE
feat: Add Skills option (parity with Python SDK)

### DIFF
--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -148,6 +148,14 @@ func BuildCommandWithPrompt(cliPath string, options *shared.Options, prompt stri
 
 // addOptionsToCommand adds all Options fields as CLI flags
 func addOptionsToCommand(cmd []string, options *shared.Options) []string {
+	// Apply Skills option by transforming AllowedTools and SettingSources before
+	// any flags are emitted. Matches the Python SDK's _apply_skills_defaults.
+	if options.Skills != nil {
+		copied := *options
+		copied.AllowedTools, copied.SettingSources = applySkillsDefaults(options)
+		options = &copied
+	}
+
 	cmd = addToolControlFlags(cmd, options)
 	cmd = addToolsFlag(cmd, options)
 	cmd = addModelAndPromptFlags(cmd, options)
@@ -466,6 +474,50 @@ func CheckCLIVersion(ctx context.Context, cliPath string) (warning string) {
 	}
 
 	return ""
+}
+
+// applySkillsDefaults computes the effective AllowedTools and SettingSources for
+// the Skills option without mutating the input. When Skills is "all", appends the
+// bare "Skill" tool; when it is a []string, appends "Skill(name)" for each entry.
+// When Skills is non-nil and SettingSources is unset, defaults SettingSources to
+// [user, project] so the CLI discovers installed Skills. Mirrors the Python SDK's
+// _apply_skills_defaults in subprocess_cli.py.
+func applySkillsDefaults(options *shared.Options) ([]string, []shared.SettingSource) {
+	allowedTools := append([]string(nil), options.AllowedTools...)
+	settingSources := options.SettingSources
+
+	switch s := options.Skills.(type) {
+	case nil:
+		return allowedTools, settingSources
+	case string:
+		if s == shared.SkillsAll && !containsString(allowedTools, "Skill") {
+			allowedTools = append(allowedTools, "Skill")
+		}
+	case []string:
+		for _, name := range s {
+			pattern := fmt.Sprintf("Skill(%s)", name)
+			if !containsString(allowedTools, pattern) {
+				allowedTools = append(allowedTools, pattern)
+			}
+		}
+	}
+
+	if settingSources == nil {
+		settingSources = []shared.SettingSource{
+			shared.SettingSourceUser,
+			shared.SettingSourceProject,
+		}
+	}
+	return allowedTools, settingSources
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
 }
 
 // compareVersionParts compares two X.Y.Z versions.

--- a/internal/cli/discovery_test.go
+++ b/internal/cli/discovery_test.go
@@ -1698,3 +1698,122 @@ func createVersionMockCLI(t *testing.T, version string) string {
 	}
 	return mockCLI
 }
+
+// TestSkillsFlagSupport tests that the Skills option transforms AllowedTools
+// and defaults SettingSources, matching the Python SDK's _apply_skills_defaults.
+func TestSkillsFlagSupport(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  *shared.Options
+		validate func(*testing.T, []string)
+	}{
+		{
+			name:     "skills_all_adds_skill_tool",
+			options:  &shared.Options{Skills: shared.SkillsAll},
+			validate: validateSkillsAll,
+		},
+		{
+			name: "skills_list_adds_scoped_skill_tools",
+			options: &shared.Options{
+				Skills: []string{"pdf", "docx"},
+			},
+			validate: validateSkillsList,
+		},
+		{
+			name:     "skills_disabled_does_not_add_skill_tool",
+			options:  &shared.Options{Skills: []string{}},
+			validate: validateSkillsDisabled,
+		},
+		{
+			name: "skills_defaults_setting_sources_to_user_project",
+			options: &shared.Options{
+				Skills: shared.SkillsAll,
+			},
+			validate: validateSkillsDefaultsSettingSources,
+		},
+		{
+			name: "skills_does_not_override_explicit_setting_sources",
+			options: &shared.Options{
+				Skills:         shared.SkillsAll,
+				SettingSources: []shared.SettingSource{shared.SettingSourceLocal},
+			},
+			validate: validateSkillsPreservesSettingSources,
+		},
+		{
+			name: "skills_all_does_not_duplicate_existing_skill_tool",
+			options: &shared.Options{
+				AllowedTools: []string{"Skill", "Read"},
+				Skills:       shared.SkillsAll,
+			},
+			validate: validateSkillsNoDuplicate,
+		},
+		{
+			name: "skills_preserves_existing_allowed_tools",
+			options: &shared.Options{
+				AllowedTools: []string{"Read", "Write"},
+				Skills:       []string{"pdf"},
+			},
+			validate: validateSkillsPreservesAllowedTools,
+		},
+		{
+			name:     "skills_nil_is_noop",
+			options:  &shared.Options{AllowedTools: []string{"Read"}},
+			validate: validateSkillsNoop,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := BuildCommand("/usr/local/bin/claude", test.options, true)
+			test.validate(t, cmd)
+		})
+	}
+}
+
+func validateSkillsAll(t *testing.T, cmd []string) {
+	t.Helper()
+	assertContainsArgs(t, cmd, "--allowed-tools", "Skill")
+}
+
+func validateSkillsList(t *testing.T, cmd []string) {
+	t.Helper()
+	assertContainsArgs(t, cmd, "--allowed-tools", "Skill(pdf),Skill(docx)")
+}
+
+func validateSkillsDisabled(t *testing.T, cmd []string) {
+	t.Helper()
+	for i, arg := range cmd {
+		if arg == "--allowed-tools" && i+1 < len(cmd) {
+			if strings.Contains(cmd[i+1], "Skill") {
+				t.Errorf("Expected no Skill tool in --allowed-tools, got %q", cmd[i+1])
+			}
+		}
+	}
+}
+
+func validateSkillsDefaultsSettingSources(t *testing.T, cmd []string) {
+	t.Helper()
+	assertContainsArgs(t, cmd, "--setting-sources", "user,project")
+}
+
+func validateSkillsPreservesSettingSources(t *testing.T, cmd []string) {
+	t.Helper()
+	assertContainsArgs(t, cmd, "--setting-sources", "local")
+}
+
+func validateSkillsNoDuplicate(t *testing.T, cmd []string) {
+	t.Helper()
+	assertContainsArgs(t, cmd, "--allowed-tools", "Skill,Read")
+}
+
+func validateSkillsPreservesAllowedTools(t *testing.T, cmd []string) {
+	t.Helper()
+	assertContainsArgs(t, cmd, "--allowed-tools", "Read,Write,Skill(pdf)")
+}
+
+func validateSkillsNoop(t *testing.T, cmd []string) {
+	t.Helper()
+	// AllowedTools unchanged; SettingSources stays at the global default (empty).
+	assertContainsArgs(t, cmd, "--allowed-tools", "Read")
+	assertContainsArgs(t, cmd, "--setting-sources", "")
+}

--- a/internal/shared/options.go
+++ b/internal/shared/options.go
@@ -40,6 +40,10 @@ type ToolsPreset struct {
 	Preset string `json:"preset"` // e.g., "claude_code"
 }
 
+// SkillsAll is the sentinel string value for Options.Skills that enables every
+// discovered Skill. Mirrors the Python SDK's skills="all" value.
+const SkillsAll = "all"
+
 // SettingSource represents a settings source location.
 type SettingSource string
 
@@ -182,6 +186,14 @@ type Options struct {
 	Settings             *string         `json:"settings,omitempty"`
 	ForkSession          bool            `json:"fork_session,omitempty"`
 	SettingSources       []SettingSource `json:"setting_sources,omitempty"`
+
+	// Skills controls which filesystem-discovered Skills are exposed to the model.
+	// Accepts the string "all" (SkillsAll) to enable every discovered Skill, a
+	// []string of Skill names to enable only those, or an empty []string{} to
+	// disable all. When non-nil and SettingSources is unset, SettingSources
+	// defaults to [user, project] so the CLI discovers installed Skills.
+	// Matches the Python SDK's skills option (see _apply_skills_defaults).
+	Skills any `json:"skills,omitempty"`
 
 	// Partial Message Streaming
 	IncludePartialMessages bool `json:"include_partial_messages,omitempty"`

--- a/options.go
+++ b/options.go
@@ -313,6 +313,47 @@ func WithSettingSources(sources ...SettingSource) Option {
 	}
 }
 
+// SkillsAll is the sentinel value for enabling every discovered Skill.
+// Passing this to WithSkills enables all Skills found on the filesystem.
+const SkillsAll = shared.SkillsAll
+
+// WithSkills sets the Skills configuration directly.
+// Accepts the string "all" (use SkillsAll) to enable every discovered Skill,
+// a []string of Skill names to enable only those, or []string{} to disable all.
+// When set, SettingSources defaults to [user, project] if unset so the CLI
+// discovers installed Skills. Mirrors the Python SDK's skills option.
+func WithSkills(skills any) Option {
+	return func(o *Options) {
+		o.Skills = skills
+	}
+}
+
+// WithSkillsAll enables every discovered Skill in the session.
+func WithSkillsAll() Option {
+	return func(o *Options) {
+		o.Skills = SkillsAll
+	}
+}
+
+// WithSkillsList enables only the named Skills.
+// Names match the name field in SKILL.md or the Skill's directory name.
+// Use "plugin:skill" for plugin-provided Skills.
+func WithSkillsList(names ...string) Option {
+	return func(o *Options) {
+		// Always store a non-nil slice so callers can distinguish from unset.
+		list := make([]string, len(names))
+		copy(list, names)
+		o.Skills = list
+	}
+}
+
+// WithSkillsDisabled disables all Skills in the session.
+func WithSkillsDisabled() Option {
+	return func(o *Options) {
+		o.Skills = []string{}
+	}
+}
+
 // WithExtraArgs sets arbitrary CLI flags via ExtraArgs.
 func WithExtraArgs(args map[string]*string) Option {
 	return func(o *Options) {

--- a/options_test.go
+++ b/options_test.go
@@ -1631,6 +1631,82 @@ func TestPluginsMixedWithOtherOptions(t *testing.T) {
 	assertOptionsBetas(t, options.Betas, []SdkBeta{SdkBetaContext1M})
 }
 
+// TestWithSkillsOption tests the Skills functional options.
+func TestWithSkillsOption(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() *Options
+		expected any
+	}{
+		{
+			name:     "skills_all_via_helper",
+			setup:    func() *Options { return NewOptions(WithSkillsAll()) },
+			expected: SkillsAll,
+		},
+		{
+			name:     "skills_all_via_with_skills",
+			setup:    func() *Options { return NewOptions(WithSkills(SkillsAll)) },
+			expected: SkillsAll,
+		},
+		{
+			name:     "skills_list",
+			setup:    func() *Options { return NewOptions(WithSkillsList("pdf", "docx")) },
+			expected: []string{"pdf", "docx"},
+		},
+		{
+			name:     "skills_list_via_with_skills",
+			setup:    func() *Options { return NewOptions(WithSkills([]string{"a", "b"})) },
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "skills_disabled",
+			setup:    func() *Options { return NewOptions(WithSkillsDisabled()) },
+			expected: []string{},
+		},
+		{
+			name:     "skills_unset_is_nil",
+			setup:    func() *Options { return NewOptions() },
+			expected: nil,
+		},
+		{
+			name: "override_skills",
+			setup: func() *Options {
+				return NewOptions(
+					WithSkillsList("first"),
+					WithSkillsAll(),
+				)
+			},
+			expected: SkillsAll,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := tt.setup()
+			switch want := tt.expected.(type) {
+			case nil:
+				if options.Skills != nil {
+					t.Errorf("Expected Skills = nil, got %v", options.Skills)
+				}
+			case string:
+				got, ok := options.Skills.(string)
+				if !ok {
+					t.Fatalf("Expected Skills to be string, got %T", options.Skills)
+				}
+				if got != want {
+					t.Errorf("Expected Skills = %q, got %q", want, got)
+				}
+			case []string:
+				got, ok := options.Skills.([]string)
+				if !ok {
+					t.Fatalf("Expected Skills to be []string, got %T", options.Skills)
+				}
+				assertOptionsStringSlice(t, got, want, "Skills")
+			}
+		})
+	}
+}
+
 // assertOptionsPlugins verifies Plugins slice values
 func assertOptionsPlugins(t *testing.T, actual, expected []SdkPluginConfig) {
 	t.Helper()


### PR DESCRIPTION
## Summary

Adds the `Skills` configuration option to bring the Go SDK to parity with the official Python and TypeScript Agent SDKs. Without it, Go callers can only get the default all-on Skill behavior — they cannot selectively enable a subset or disable Skills entirely for a session.

## API

- `WithSkillsAll()` — enables every discovered Skill
- `WithSkillsList(names ...string)` — enables only the named Skills
- `WithSkillsDisabled()` — disables all Skills in the session
- `WithSkills(any)` — accepts `SkillsAll` or `[]string` directly (mirrors the existing `Tools any` polymorphic pattern)
- `SkillsAll` constant (= `"all"`)

## Wire format

Mirrors the Python SDK's [`_apply_skills_defaults`](https://github.com/anthropics/claude-agent-sdk-python/blob/main/src/claude_agent_sdk/_internal/transport/subprocess_cli.py) exactly — no new CLI flag is emitted. Instead, `Skills` transforms `AllowedTools` and `SettingSources` before flag emission:

| `Skills` value      | Effect on `--allowed-tools`           | Effect on `--setting-sources`         |
|---------------------|---------------------------------------|---------------------------------------|
| `"all"`             | appends `Skill`                       | defaults to `user,project` if unset   |
| `[]string{a, b}`    | appends `Skill(a)`, `Skill(b)`        | defaults to `user,project` if unset   |
| `[]string{}`        | unchanged (Skill tool absent)         | defaults to `user,project` if unset   |
| `nil` (unset)       | unchanged                             | unchanged                             |

Existing `AllowedTools` entries are preserved; duplicate `Skill` entries are not added. Explicitly-set `SettingSources` are never overridden.

## Testing

- `TestWithSkillsOption` in `options_test.go` — covers all four option helpers, the polymorphic `WithSkills(any)` form, unset/nil semantics, and override-last-wins
- `TestSkillsFlagSupport` in `internal/cli/discovery_test.go` — covers each wire-format case above, plus interaction with pre-existing `AllowedTools` and explicit `SettingSources`
- `make check` and `go test -race ./...` both green; no new lint issues introduced (the existing 52 pre-existing `goconst`/`gosec` findings on `main` are unchanged)

## Related

- Python parity: [skills option](https://github.com/anthropics/claude-agent-sdk-python/blob/main/src/claude_agent_sdk/_internal/transport/subprocess_cli.py) (`_apply_skills_defaults`)
- TypeScript parity: [skills option](https://code.claude.com/docs/en/agent-sdk/skills)