### PR TITLE
feat: Add WithEffort option for --effort CLI flag

### DIFF
--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -215,6 +215,9 @@ func addModelAndPromptFlags(cmd []string, options *shared.Options) []string {
 	if options.FallbackModel != nil {
 		cmd = append(cmd, "--fallback-model", *options.FallbackModel)
 	}
+	if options.Effort != nil {
+		cmd = append(cmd, "--effort", *options.Effort)
+	}
 	if options.MaxBudgetUSD != nil {
 		cmd = append(cmd, "--max-budget-usd", fmt.Sprintf("%.2f", *options.MaxBudgetUSD))
 	}

--- a/internal/cli/discovery_test.go
+++ b/internal/cli/discovery_test.go
@@ -99,6 +99,18 @@ func TestCwdNotAddedToCommand(t *testing.T) {
 	}
 }
 
+// TestEffortFlagSupport tests that the Effort option maps to the --effort flag.
+func TestEffortFlagSupport(t *testing.T) {
+	effort := "high"
+	options := &shared.Options{Effort: &effort}
+	cmd := BuildCommand("/usr/local/bin/claude", options, false)
+	assertContainsArgs(t, cmd, "--effort", "high")
+
+	// When Effort is unset, no --effort flag should be emitted.
+	cmd = BuildCommand("/usr/local/bin/claude", &shared.Options{}, false)
+	assertNotContainsArg(t, cmd, "--effort")
+}
+
 // TestCLIDiscoveryLocations tests CLI discovery path generation
 func TestCLIDiscoveryLocations(t *testing.T) {
 	locations := getCommonCLILocations()

--- a/internal/shared/options.go
+++ b/internal/shared/options.go
@@ -133,6 +133,23 @@ const (
 	AgentModelInherit AgentModel = "inherit"
 )
 
+// EffortLevel controls how many tokens Claude spends per response, trading off
+// thoroughness against token efficiency. Maps to the CLI's --effort flag.
+type EffortLevel string
+
+const (
+	// EffortLow minimizes token usage.
+	EffortLow EffortLevel = "low"
+	// EffortMedium balances token usage and thoroughness.
+	EffortMedium EffortLevel = "medium"
+	// EffortHigh favors thoroughness over token efficiency.
+	EffortHigh EffortLevel = "high"
+	// EffortXHigh requests the highest effort (model-dependent).
+	EffortXHigh EffortLevel = "xhigh"
+	// EffortMax requests maximum effort (model-dependent, session-only).
+	EffortMax EffortLevel = "max"
+)
+
 // AgentDefinition defines a programmatic subagent.
 type AgentDefinition struct {
 	// Description is a brief description of the agent's purpose.
@@ -166,6 +183,7 @@ type Options struct {
 	AppendSystemPrompt *string `json:"append_system_prompt,omitempty"`
 	Model              *string `json:"model,omitempty"`
 	FallbackModel      *string `json:"fallback_model,omitempty"`
+	Effort             *string `json:"effort,omitempty"`
 	MaxThinkingTokens  int     `json:"max_thinking_tokens,omitempty"`
 
 	// Budget & Billing

--- a/options.go
+++ b/options.go
@@ -57,6 +57,9 @@ type SdkPluginConfig = shared.SdkPluginConfig
 // OutputFormat specifies the format for structured output.
 type OutputFormat = shared.OutputFormat
 
+// EffortLevel controls how many tokens Claude spends per response.
+type EffortLevel = shared.EffortLevel
+
 // CanUseToolCallback is invoked when CLI requests permission to use a tool.
 // The callback receives tool name, input parameters, and permission context.
 // Return PermissionResultAllow to permit, PermissionResultDeny to deny.
@@ -102,6 +105,11 @@ const (
 	SettingSourceProject            = shared.SettingSourceProject
 	SettingSourceLocal              = shared.SettingSourceLocal
 	SdkPluginTypeLocal              = shared.SdkPluginTypeLocal
+	EffortLow                       = shared.EffortLow
+	EffortMedium                    = shared.EffortMedium
+	EffortHigh                      = shared.EffortHigh
+	EffortXHigh                     = shared.EffortXHigh
+	EffortMax                       = shared.EffortMax
 )
 
 // Permission update type constants
@@ -178,6 +186,16 @@ func WithModel(model string) Option {
 func WithFallbackModel(model string) Option {
 	return func(o *Options) {
 		o.FallbackModel = &model
+	}
+}
+
+// WithEffort sets the effort level (--effort), controlling how many tokens
+// Claude spends per response. Known levels are EffortLow..EffortMax, but any
+// value is passed through to the CLI to tolerate future levels.
+func WithEffort(effort EffortLevel) Option {
+	return func(o *Options) {
+		s := string(effort)
+		o.Effort = &s
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -1096,6 +1096,34 @@ func TestFallbackModelOption(t *testing.T) {
 	})
 }
 
+func TestEffortOption(t *testing.T) {
+	tests := []struct {
+		name     string
+		effort   EffortLevel
+		expected string
+	}{
+		{"low", EffortLow, "low"},
+		{"medium", EffortMedium, "medium"},
+		{"high", EffortHigh, "high"},
+		{"xhigh", EffortXHigh, "xhigh"},
+		{"max", EffortMax, "max"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := NewOptions(WithEffort(tt.effort))
+			assertOptionsEffort(t, options, tt.expected)
+		})
+	}
+
+	// Test nil case
+	t.Run("nil_by_default", func(t *testing.T) {
+		options := NewOptions()
+		assertOptionsEffortNil(t, options)
+	})
+}
+
 func TestUserOption(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1207,6 +1235,26 @@ func assertOptionsFallbackModelNil(t *testing.T, options *Options) {
 	t.Helper()
 	if options.FallbackModel != nil {
 		t.Errorf("Expected FallbackModel = nil, got %q", *options.FallbackModel)
+	}
+}
+
+// assertOptionsEffort verifies Effort value
+func assertOptionsEffort(t *testing.T, options *Options, expected string) {
+	t.Helper()
+	if options.Effort == nil {
+		t.Error("Expected Effort to be set, got nil")
+		return
+	}
+	if *options.Effort != expected {
+		t.Errorf("Expected Effort = %q, got %q", expected, *options.Effort)
+	}
+}
+
+// assertOptionsEffortNil verifies Effort is nil
+func assertOptionsEffortNil(t *testing.T, options *Options) {
+	t.Helper()
+	if options.Effort != nil {
+		t.Errorf("Expected Effort = nil, got %q", *options.Effort)
 	}
 }
 


### PR DESCRIPTION
## Description

Adds a `WithEffort` functional option that maps to the Claude Code CLI's `--effort` flag, bringing the Go SDK to parity with the Python/TypeScript SDKs' `effort` option. The flag controls how many tokens Claude spends per response (trading thoroughness against token efficiency).

### Changes

- **`internal/shared/options.go`**: add `EffortLevel` type with `EffortLow`/`EffortMedium`/`EffortHigh`/`EffortXHigh`/`EffortMax` constants, and an `Effort *string` field on `Options`.
- **`options.go`**: re-export `EffortLevel` and the constants; add `WithEffort(EffortLevel)` following the `WithXxx()` convention (next to `WithFallbackModel`).
- **`internal/cli/discovery.go`**: emit `--effort <value>` in `addModelAndPromptFlags`, mirroring `--fallback-model`.
- **`internal/cli/discovery_test.go`**: `TestEffortFlagSupport`.

### Design notes

- Typed constants are provided for ergonomics, but the value is passed through to the CLI as-is (not validated against the known set) so the SDK tolerates future effort levels without a code change — consistent with the existing `WithModel`/`WithFallbackModel` behavior.
- The valid levels (`low`, `medium`, `high`, `xhigh`, `max`) were verified against the Claude Code CLI v2.1.160.

## Related issue

No existing issue — there were no open issues or PRs tracking effort support.

## Test plan

- `go build ./...` — passes
- `go vet ./...` — clean
- `gofmt -l .` — clean; `gocyclo -over 15 .` — no new offenders
- `go test ./...` — full suite passes, including the new `TestEffortFlagSupport` which asserts `WithEffort(EffortHigh)` produces `--effort high` and that no `--effort` flag is emitted when unset
- Manual smoke: `claude --effort high -p "..."` runs with no "unknown value" warning

## PR checklist

- [x] All tests pass
- [x] No new linting errors (pre-existing `goconst`/`gosec` findings in `validator_test.go` are unrelated)
- [x] Code follows style guidelines (functional options, conventional commit)
- [x] Documentation updated (GoDoc on new symbols)
- [x] Commit messages follow conventions