### PR TITLE
fix: don't fail session parsing on JSONL lines over 1MB

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -505,25 +505,7 @@ func parseJSONLFile(path string) (entries []jsonlEntry, err error) {
 		}
 	}()
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-		var raw map[string]any
-		if uerr := json.Unmarshal(line, &raw); uerr != nil {
-			continue // skip malformed lines
-		}
-		typ, _ := raw["type"].(string)
-		entries = append(entries, jsonlEntry{entryType: typ, raw: raw})
-	}
-	if serr := scanner.Err(); serr != nil {
-		return nil, fmt.Errorf("scanning JSONL file: %w", serr)
-	}
-	return entries, nil
+	return parseJSONLFromReader(f)
 }
 
 // maxFirstPromptLen is the maximum length of the first prompt (truncated with ellipsis).
@@ -693,27 +675,31 @@ func parseJSONLHeadTail(path string, bufSize int64) (entries []jsonlEntry, err e
 }
 
 // parseJSONLFromReader reads all lines from an already-opened file.
+// Lines can be arbitrarily long (a base64-embedded document attachment
+// exceeds bufio.Scanner's default-style caps), so read with bufio.Reader,
+// which grows to fit each line instead of erroring.
 func parseJSONLFromReader(f *os.File) ([]jsonlEntry, error) {
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	r := bufio.NewReaderSize(f, 64*1024)
 
 	var entries []jsonlEntry
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
+	for {
+		line, rerr := r.ReadBytes('\n')
+		line = bytes.TrimRight(line, "\r\n")
+		if len(line) > 0 {
+			var raw map[string]any
+			if err := json.Unmarshal(line, &raw); err == nil {
+				typ, _ := raw["type"].(string)
+				entries = append(entries, jsonlEntry{entryType: typ, raw: raw})
+			}
+			// skip malformed lines
 		}
-		var raw map[string]any
-		if err := json.Unmarshal(line, &raw); err != nil {
-			continue
+		if rerr != nil {
+			if errors.Is(rerr, io.EOF) {
+				return entries, nil
+			}
+			return nil, fmt.Errorf("scanning JSONL file: %w", rerr)
 		}
-		typ, _ := raw["type"].(string)
-		entries = append(entries, jsonlEntry{entryType: typ, raw: raw})
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scanning JSONL file: %w", err)
-	}
-	return entries, nil
 }
 
 // parseLinesFromBytes parses complete JSONL lines from a byte buffer.

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1150,6 +1150,34 @@ not valid json
 	}
 }
 
+// Regression: a transcript line can exceed 1MB (e.g. a base64-embedded PDF
+// attachment). Parsing must not fail with bufio.Scanner's "token too long".
+func TestParseJSONLHandlesOversizedLines(t *testing.T) {
+	_, projDir := setupTestProject(t)
+
+	// ~2MB of base64-looking payload embedded in one user message.
+	bigData := strings.Repeat("JVBERi0xLjYNJeLj", 128*1024)
+	path := filepath.Join(projDir, "oversized.jsonl")
+	content := `{"type":"user","uuid":"u1","message":{"role":"user","content":"hello"},"timestamp":"2026-01-01T00:00:00Z"}
+{"type":"user","uuid":"u2","message":{"role":"user","content":[{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"` + bigData + `"}}]},"timestamp":"2026-01-01T00:00:01Z"}
+{"type":"assistant","uuid":"a1","message":{"role":"assistant","content":[{"type":"text","text":"read it"}]},"timestamp":"2026-01-01T00:00:02Z"}
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	entries, err := parseJSONLFile(path)
+	if err != nil {
+		t.Fatalf("parseJSONLFile() error: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3 (oversized line must parse, not abort the read)", len(entries))
+	}
+	if entries[2].entryType != "assistant" {
+		t.Errorf("entries[2].entryType = %q, want %q (entries after the oversized line must survive)", entries[2].entryType, "assistant")
+	}
+}
+
 // --- Worktree support tests ---
 
 func TestGetWorktreePaths(t *testing.T) {


### PR DESCRIPTION
## Problem

Session transcripts can contain single lines far larger than 1MB. For example, when a session reads a fetched PDF, the CLI embeds the whole document as one base64 `document` block in the transcript — a 1MB PDF becomes a ~1.37MB JSONL line.

`parseJSONLFile` and `parseJSONLFromReader` cap `bufio.Scanner` at 1MB:

```go
scanner := bufio.NewScanner(f)
scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
```

Once such a line exists, `GetSessionMessages` / `GetSessionInfo` fail with `scanning JSONL file: bufio.Scanner: token too long` — permanently for that session, since the line stays in the transcript on disk.

## Fix

Replace the capped Scanner with `bufio.Reader.ReadBytes('\n')`, which still streams line by line but grows its buffer to fit each line instead of erroring, and consolidate `parseJSONLFile` onto `parseJSONLFromReader`. Malformed lines are still skipped.

This matches the Python SDK's behavior ([sessions.py](https://github.com/anthropics/claude-agent-sdk-python/blob/main/src/claude_agent_sdk/_internal/sessions.py)): it splits the transcript on newlines with no line-length cap and skips unparseable lines with `continue`.

## Test

Added `TestParseJSONLHandlesOversizedLines`, which generates a transcript with a ~2MB line at runtime (no fixture file) and asserts the full conversation parses. It fails on the previous code with the exact error above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)