### PR TITLE
fix: reap subprocess after control init failures

### DIFF
--- a/internal/control/protocol.go
+++ b/internal/control/protocol.go
@@ -39,6 +39,7 @@ type Protocol struct {
 
 	// State
 	initialized  bool
+	initializing bool
 	initOnce     sync.Once
 	initErr      error
 	initResponse *InitializeResponse
@@ -318,10 +319,14 @@ func (p *Protocol) handleControlResponse(_ context.Context, msg map[string]any) 
 
 	p.mu.Lock()
 	responseChan, exists := p.pendingRequests[requestID]
+	initializing := p.initializing
 	p.mu.Unlock()
 
 	if !exists {
-		// Response for unknown request - ignore (could be stale or from another session)
+		if initializing {
+			return fmt.Errorf("control response request ID mismatch: received %q", requestID)
+		}
+		// Outside initialization, a response can be stale from an earlier request.
 		return nil
 	}
 
@@ -391,6 +396,15 @@ func (p *Protocol) sendErrorResponse(ctx context.Context, requestID string, errM
 // calls return the same error and will not retry even with a fresh context.
 func (p *Protocol) Initialize(ctx context.Context) (*InitializeResponse, error) {
 	p.initOnce.Do(func() {
+		p.mu.Lock()
+		p.initializing = true
+		p.mu.Unlock()
+		defer func() {
+			p.mu.Lock()
+			p.initializing = false
+			p.mu.Unlock()
+		}()
+
 		// Build initialize request with hooks configuration
 		initReq := InitializeRequest{
 			Subtype: SubtypeInitialize,
@@ -432,6 +446,13 @@ func (p *Protocol) Initialize(ctx context.Context) (*InitializeResponse, error) 
 	p.mu.Unlock()
 
 	return resp, err
+}
+
+// IsInitialized reports whether the initialize handshake completed.
+func (p *Protocol) IsInitialized() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.initialized
 }
 
 // Interrupt sends an interrupt control request to the CLI.

--- a/internal/subprocess/io.go
+++ b/internal/subprocess/io.go
@@ -2,6 +2,7 @@ package subprocess
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -10,6 +11,29 @@ import (
 	"github.com/severity1/claude-agent-sdk-go/internal/parser"
 	"github.com/severity1/claude-agent-sdk-go/internal/shared"
 )
+
+var errStdoutEOFDuringInit = errors.New("stdout EOF before control response")
+
+func (t *Transport) reportInitializationFailure(err error) {
+	if err == nil || t.initFailure == nil {
+		return
+	}
+	select {
+	case t.initFailure <- err:
+	default:
+	}
+}
+
+func (t *Transport) reportStreamError(err error) {
+	if err == nil {
+		return
+	}
+	t.reportInitializationFailure(err)
+	select {
+	case t.errChan <- err:
+	case <-t.ctx.Done():
+	}
+}
 
 // handleStdout processes stdout in a separate goroutine
 func (t *Transport) handleStdout() {
@@ -40,15 +64,15 @@ func (t *Transport) handleStdout() {
 		if line == "" {
 			continue
 		}
+		if !json.Valid([]byte(line)) {
+			t.reportStreamError(errors.New("invalid JSONL control record"))
+			continue
+		}
 
 		// Parse line with the parser
 		messages, err := t.parser.ProcessLine(line)
 		if err != nil {
-			select {
-			case t.errChan <- err:
-			case <-t.ctx.Done():
-				return
-			}
+			t.reportStreamError(err)
 			continue
 		}
 
@@ -69,7 +93,9 @@ func (t *Transport) handleStdout() {
 				if t.protocol != nil {
 					// HandleIncomingMessage routes control responses to pending requests
 					// and forwards non-control messages to the protocol's message stream
-					_ = t.protocol.HandleIncomingMessage(t.ctx, rawCtrl.Data)
+					if err := t.protocol.HandleIncomingMessage(t.ctx, rawCtrl.Data); err != nil {
+						t.reportStreamError(err)
+					}
 				}
 				// Don't send control messages to msgChan - they're internal to the protocol
 				continue
@@ -87,11 +113,10 @@ func (t *Transport) handleStdout() {
 	}
 
 	if err := scanner.Err(); err != nil {
-		select {
-		case t.errChan <- fmt.Errorf("stdout scanner error: %w", err):
-		case <-t.ctx.Done():
-		}
+		t.reportStreamError(fmt.Errorf("stdout scanner error: %w", err))
+		return
 	}
+	t.reportInitializationFailure(errStdoutEOFDuringInit)
 }
 
 // handleStderrCallback processes stderr in a separate goroutine.
@@ -134,7 +159,7 @@ func (t *Transport) handleStderrCallback() {
 // unblock Initialize().
 func (t *Transport) routeInitError(msg shared.Message) {
 	resultMsg, ok := msg.(*shared.ResultMessage)
-	if !ok || t.connected || !resultMsg.IsError || t.protocol == nil {
+	if !ok || !resultMsg.IsError || t.protocol == nil || t.protocol.IsInitialized() {
 		return
 	}
 	t.protocol.HandleControlInitErr(errors.New(formatInitError(resultMsg)))

--- a/internal/subprocess/lifecycle_fault_test.go
+++ b/internal/subprocess/lifecycle_fault_test.go
@@ -1,0 +1,226 @@
+//go:build !windows
+
+package subprocess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/severity1/claude-agent-sdk-go/internal/control"
+	"github.com/severity1/claude-agent-sdk-go/internal/shared"
+)
+
+const lifecycleFailureDeadline = 500 * time.Millisecond
+
+func TestConnectFailureClassifiesAndReapsProcess(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		errorContains string
+	}{
+		{
+			name:          "process exits before initialize response",
+			body:          "exit 17",
+			errorContains: "process exited before control response",
+		},
+		{
+			name:          "stdout closes before initialize response",
+			body:          "exec 1>&-\nwhile :; do :; done",
+			errorContains: "stdout EOF before control response",
+		},
+		{
+			name:          "invalid JSONL fails immediately",
+			body:          "printf '%s\\n' 'not-json'\nwhile :; do :; done",
+			errorContains: "invalid JSONL control record",
+		},
+		{
+			name: "mismatched request id fails immediately",
+			body: "IFS= read -r _\n" +
+				"printf '%s\\n' '{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\",\"request_id\":\"req_wrong\",\"response\":{}}}'\n" +
+				"while :; do :; done",
+			errorContains: "control response request ID mismatch",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cliPath, pidFile := writeLifecycleCLI(t, tc.body)
+			transport := newLifecycleTransport(cliPath, pidFile)
+			ctx, cancel := context.WithTimeout(context.Background(), lifecycleFailureDeadline)
+			defer cancel()
+
+			started := time.Now()
+			err := transport.Connect(ctx)
+			duration := time.Since(started)
+			pid := readLifecyclePID(t, pidFile)
+			defer forceReapLifecycleProcess(pid)
+
+			if err == nil {
+				t.Fatal("Connect() error = nil, want classified initialization failure")
+			}
+			if !strings.Contains(err.Error(), tc.errorContains) {
+				t.Fatalf("Connect() error = %q, want substring %q", err, tc.errorContains)
+			}
+			if duration >= lifecycleFailureDeadline {
+				t.Fatalf("Connect() returned after %s; want failure before context deadline %s", duration, lifecycleFailureDeadline)
+			}
+
+			assertLifecycleProcessReaped(t, pid)
+		})
+	}
+}
+
+func TestConnectCancellationReapsHungInitialize(t *testing.T) {
+	cliPath, pidFile := writeLifecycleCLI(t, "IFS= read -r _\nwhile :; do :; done")
+	transport := newLifecycleTransport(cliPath, pidFile)
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	err := transport.Connect(ctx)
+	if err == nil {
+		t.Fatal("Connect() error = nil, want context cancellation")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Connect() error = %v, want context deadline exceeded in chain", err)
+	}
+
+	pid := readLifecyclePID(t, pidFile)
+	defer forceReapLifecycleProcess(pid)
+	assertLifecycleProcessReaped(t, pid)
+}
+
+func TestConcurrentCancelAndCloseReapsProcess(t *testing.T) {
+	cliPath, pidFile := writeLifecycleCLI(t, `
+IFS= read -r request
+request_id=$(printf '%s' "$request" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{"supported_commands":[]}}}\n' "$request_id"
+while IFS= read -r _; do :; done
+`)
+	transport := newLifecycleTransport(cliPath, pidFile)
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := transport.Connect(ctx); err != nil {
+		cancel()
+		t.Fatalf("Connect() error = %v, want success", err)
+	}
+	pid := readLifecyclePID(t, pidFile)
+	defer forceReapLifecycleProcess(pid)
+
+	cancel()
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- transport.Close() }()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() did not finish after context cancellation")
+	}
+
+	assertLifecycleProcessReaped(t, pid)
+}
+
+func newLifecycleTransport(cliPath, pidFile string) *Transport {
+	return New(cliPath, &shared.Options{
+		ExtraEnv: map[string]string{"SDK_TEST_PID_FILE": pidFile},
+		Hooks: map[control.HookEvent][]control.HookMatcher{
+			control.HookEventPreToolUse: nil,
+		},
+	}, false, "sdk-go-client")
+}
+
+func writeLifecycleCLI(t *testing.T, body string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "pid")
+	path := filepath.Join(dir, "claude")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "${1:-}" = "-v" ]; then
+  printf '3.0.0\n'
+  exit 0
+fi
+printf '%%s\n' "$$" > "$SDK_TEST_PID_FILE"
+%s
+`, body)
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+	// #nosec G302 -- executable test-only fake CLI created under t.TempDir.
+	if err := os.Chmod(path, 0o700); err != nil {
+		t.Fatalf("chmod fake CLI: %v", err)
+	}
+	return path, pidFile
+}
+
+func readLifecyclePID(t *testing.T, pidFile string) int {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		// #nosec G304 -- pidFile is created under t.TempDir by writeLifecycleCLI.
+		data, err := os.ReadFile(filepath.Clean(pidFile))
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr != nil {
+				t.Fatalf("parse fake CLI PID: %v", parseErr)
+			}
+			return pid
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("read fake CLI PID: %v", err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("fake CLI did not write PID file %s", pidFile)
+	return 0
+}
+
+func assertLifecycleProcessReaped(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(300 * time.Millisecond)
+	procPath := filepath.Join("/proc", strconv.Itoa(pid))
+	for time.Now().Before(deadline) {
+		_, err := os.Stat(procPath)
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("stat %s: %v", procPath, err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// #nosec G304 -- procPath is built from a PID emitted by the test child.
+	state, _ := os.ReadFile(filepath.Clean(filepath.Join(procPath, "status")))
+	t.Fatalf("fake CLI pid %d was not reaped; status:\n%s", pid, boundedLifecycleStatus(state))
+}
+
+func boundedLifecycleStatus(status []byte) string {
+	var kept []string
+	for _, line := range strings.Split(string(status), "\n") {
+		if strings.HasPrefix(line, "Name:") || strings.HasPrefix(line, "State:") || strings.HasPrefix(line, "PPid:") {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+func forceReapLifecycleProcess(pid int) {
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+	var status syscall.WaitStatus
+	for {
+		_, err := syscall.Wait4(pid, &status, 0, nil)
+		if err == nil || errors.Is(err, syscall.ECHILD) {
+			return
+		}
+		if !errors.Is(err, syscall.EINTR) {
+			return
+		}
+	}
+}

--- a/internal/subprocess/process.go
+++ b/internal/subprocess/process.go
@@ -1,11 +1,53 @@
 package subprocess
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/severity1/claude-agent-sdk-go/internal/shared"
 )
+
+const processExitArbitrationDelay = 25 * time.Millisecond
+
+type processResult struct {
+	err      error
+	exitCode int
+}
+
+// startProcessWaiter establishes the sole cmd.Wait owner for this process.
+func (t *Transport) startProcessWaiter() {
+	done := make(chan struct{})
+	cmd := t.cmd
+	t.processMu.Lock()
+	t.processDone = done
+	t.processResult = processResult{}
+	t.processMu.Unlock()
+
+	go func() {
+		err := cmd.Wait()
+		exitCode := 0
+		if cmd.ProcessState != nil {
+			exitCode = cmd.ProcessState.ExitCode()
+		}
+		t.processMu.Lock()
+		t.processResult = processResult{err: err, exitCode: exitCode}
+		t.processMu.Unlock()
+		close(done)
+	}()
+}
+
+func (t *Transport) processExitBeforeControlResponseError() error {
+	t.processMu.RLock()
+	result := t.processResult
+	t.processMu.RUnlock()
+	if result.err == nil && result.exitCode == 0 {
+		return fmt.Errorf("process exited before control response")
+	}
+	return shared.NewProcessError("process exited before control response", result.exitCode, "")
+}
 
 // isProcessAlreadyFinishedError checks if an error indicates the process has already terminated.
 // This follows the Python SDK pattern of suppressing "process not found" type errors.
@@ -20,91 +62,114 @@ func isProcessAlreadyFinishedError(err error) bool {
 		strings.Contains(errStr, "signal: killed")
 }
 
-// terminateProcess implements the 5-second SIGTERM -> SIGKILL sequence
+// terminateProcess implements the 5-second SIGTERM -> SIGKILL sequence. It
+// never calls cmd.Wait; startProcessWaiter is the sole Wait owner.
 func (t *Transport) terminateProcess() error {
-	if t.cmd == nil || t.cmd.Process == nil {
+	if t.cmd == nil || t.cmd.Process == nil || t.processDone == nil {
 		return nil
 	}
-
-	// Send SIGTERM
-	if err := t.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-		// If process is already finished, that's success
-		if isProcessAlreadyFinishedError(err) {
-			return nil
-		}
-		// If SIGTERM fails for other reasons, try SIGKILL immediately
-		killErr := t.cmd.Process.Kill()
-		if killErr != nil && !isProcessAlreadyFinishedError(killErr) {
-			return killErr
-		}
-		return nil // Don't return error for expected termination
-	}
-
-	// Wait exactly 5 seconds
-	done := make(chan error, 1)
-	// Capture cmd while we know it's valid to avoid data race
-	cmd := t.cmd
-	go func() {
-		done <- cmd.Wait()
-	}()
 
 	select {
-	case err := <-done:
-		// Normal termination or expected signals are not errors
-		if err != nil {
-			// Check if it's an expected exit signal
-			if strings.Contains(err.Error(), "signal:") {
-				return nil // Expected signal termination
+	case <-t.processDone:
+		return nil
+	default:
+	}
+
+	if err := t.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		if !isProcessAlreadyFinishedError(err) {
+			if killErr := t.cmd.Process.Kill(); killErr != nil && !isProcessAlreadyFinishedError(killErr) {
+				return killErr
 			}
 		}
-		return err
+		return t.waitForProcessReap()
+	}
+
+	select {
+	case <-t.processDone:
+		return nil
 	case <-time.After(terminationTimeoutSeconds * time.Second):
-		// Force kill after 5 seconds
 		if killErr := t.cmd.Process.Kill(); killErr != nil && !isProcessAlreadyFinishedError(killErr) {
 			return killErr
 		}
-		// Wait for process to exit after kill
-		<-done
-		return nil
-	case <-t.ctx.Done():
-		// Context canceled - force kill immediately
-		if killErr := t.cmd.Process.Kill(); killErr != nil && !isProcessAlreadyFinishedError(killErr) {
-			return killErr
-		}
-		// Wait for process to exit after kill, but don't return context error
-		// since this is normal cleanup behavior
-		<-done
-		return nil
+		return t.waitForProcessReap()
 	}
 }
 
-// cleanup cleans up all resources
+func (t *Transport) waitForProcessReap() error {
+	select {
+	case <-t.processDone:
+		return nil
+	case <-time.After(terminationTimeoutSeconds * time.Second):
+		return fmt.Errorf("timed out waiting for process reap after SIGKILL")
+	}
+}
+
+// closeStartedProcess handles failed Connect paths, where connected was never
+// published but the child still has to be terminated and reaped.
+func (t *Transport) closeStartedProcess() error {
+	if t.protocol != nil {
+		_ = t.protocol.Close()
+	}
+	if t.protocolAdapter != nil {
+		_ = t.protocolAdapter.Close()
+	}
+	if t.stdin != nil {
+		_ = t.stdin.Close()
+		t.stdin = nil
+	}
+	err := t.terminateProcess()
+	if t.cancel != nil {
+		t.cancel()
+	}
+	t.wg.Wait()
+	t.cleanup()
+	return err
+}
+
+// cleanup cleans up all resources. Started processes must be reaped before it
+// is called; this method never owns process termination.
 func (t *Transport) cleanup() {
+	if t.cancel != nil {
+		t.cancel()
+	}
+	if t.protocol != nil {
+		_ = t.protocol.Close()
+		t.protocol = nil
+	}
+	if t.protocolAdapter != nil {
+		_ = t.protocolAdapter.Close()
+		t.protocolAdapter = nil
+	}
+	if t.stdin != nil {
+		_ = t.stdin.Close()
+		t.stdin = nil
+	}
 	if t.stdout != nil {
 		_ = t.stdout.Close()
 		t.stdout = nil
 	}
-
 	if t.stderrPipe != nil {
 		_ = t.stderrPipe.Close()
 		t.stderrPipe = nil
 	}
-
 	if t.stderr != nil {
-		// Graceful cleanup matching Python SDK pattern
-		// Python: except Exception: pass
 		_ = t.stderr.Close()
-		_ = os.Remove(t.stderr.Name()) // Ignore cleanup errors
+		_ = os.Remove(t.stderr.Name())
 		t.stderr = nil
 	}
-
 	if t.mcpConfigFile != nil {
-		// Clean up temporary MCP config file
 		_ = t.mcpConfigFile.Close()
-		_ = os.Remove(t.mcpConfigFile.Name()) // Ignore cleanup errors
+		_ = os.Remove(t.mcpConfigFile.Name())
 		t.mcpConfigFile = nil
 	}
 
-	// Reset state
 	t.cmd = nil
+	t.ctx = nil
+	t.cancel = nil
+	t.connected = false
+	t.initFailure = nil
+	t.processMu.Lock()
+	t.processDone = nil
+	t.processResult = processResult{}
+	t.processMu.Unlock()
 }

--- a/internal/subprocess/transport.go
+++ b/internal/subprocess/transport.go
@@ -4,6 +4,7 @@ package subprocess
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -30,12 +31,15 @@ const (
 // Transport implements the Transport interface using subprocess communication.
 type Transport struct {
 	// Process management
-	cmd        *exec.Cmd
-	cliPath    string
-	options    *shared.Options
-	closeStdin bool
-	promptArg  *string // For one-shot queries, prompt passed as CLI argument
-	entrypoint string  // CLAUDE_CODE_ENTRYPOINT value (sdk-go or sdk-go-client)
+	cmd           *exec.Cmd
+	cliPath       string
+	options       *shared.Options
+	closeStdin    bool
+	promptArg     *string // For one-shot queries, prompt passed as CLI argument
+	entrypoint    string  // CLAUDE_CODE_ENTRYPOINT value (sdk-go or sdk-go-client)
+	processMu     sync.RWMutex
+	processDone   chan struct{}
+	processResult processResult
 
 	// Connection state
 	connected bool
@@ -57,8 +61,9 @@ type Transport struct {
 	validator *shared.StreamValidator
 
 	// Channels for communication
-	msgChan chan shared.Message
-	errChan chan error
+	msgChan     chan shared.Message
+	errChan     chan error
+	initFailure chan error
 
 	// Control protocol (for streaming mode only)
 	protocol        *control.Protocol
@@ -151,9 +156,24 @@ func (t *Transport) Connect(ctx context.Context) error {
 	// Check CLI version and warn if outdated (non-blocking)
 	t.emitCLIVersionWarning(ctx)
 
+	// Initialize all startup state before the process can emit output. This
+	// keeps fast child output from racing protocol construction.
+	t.ctx, t.cancel = context.WithCancel(ctx)
+	t.msgChan = make(chan shared.Message, channelBufferSize)
+	t.errChan = make(chan error, channelBufferSize)
+	t.initFailure = make(chan error, channelBufferSize)
+	t.parser.Reset()
+	t.validator = shared.NewStreamValidator()
+
 	// Set up I/O pipes
 	if err := t.setupIoPipes(); err != nil {
+		t.cleanup()
 		return err
+	}
+
+	if err := t.startControlProtocol(t.ctx); err != nil {
+		t.cleanup()
+		return fmt.Errorf("failed to start control protocol: %w", err)
 	}
 
 	// Start the process
@@ -164,13 +184,7 @@ func (t *Transport) Connect(ctx context.Context) error {
 			err,
 		)
 	}
-
-	// Set up context for goroutine management
-	t.ctx, t.cancel = context.WithCancel(ctx)
-
-	// Initialize channels
-	t.msgChan = make(chan shared.Message, channelBufferSize)
-	t.errChan = make(chan error, channelBufferSize)
+	t.startProcessWaiter()
 
 	// Start I/O handling goroutines
 	t.wg.Add(1)
@@ -186,18 +200,20 @@ func (t *Transport) Connect(ctx context.Context) error {
 	// The CLI still needs stdin to receive the message, even with --print flag
 	// stdin will be closed after sending the message in SendMessage()
 
-	// Set up control protocol for streaming mode only
-	if err := t.setupControlProtocol(t.ctx); err != nil {
-		return err
+	if err := t.initializeControlProtocol(t.ctx); err != nil {
+		cleanupErr := t.closeStartedProcess()
+		if cleanupErr != nil {
+			return fmt.Errorf("failed to initialize control protocol: %w (cleanup: %v)", err, cleanupErr)
+		}
+		return fmt.Errorf("failed to initialize control protocol: %w", err)
 	}
 
 	t.connected = true
 	return nil
 }
 
-// setupControlProtocol initializes control protocol for streaming mode.
-// Returns nil immediately for one-shot mode (closeStdin == true).
-func (t *Transport) setupControlProtocol(ctx context.Context) error {
+// startControlProtocol constructs the protocol before stdout processing begins.
+func (t *Transport) startControlProtocol(ctx context.Context) error {
 	if t.closeStdin {
 		return nil // One-shot mode doesn't need control protocol
 	}
@@ -206,19 +222,56 @@ func (t *Transport) setupControlProtocol(ctx context.Context) error {
 	t.protocol = control.NewProtocol(t.protocolAdapter, t.buildProtocolOptions()...)
 
 	if err := t.protocol.Start(ctx); err != nil {
-		t.cleanup()
-		return fmt.Errorf("failed to start control protocol: %w", err)
+		return err
 	}
-
-	// Perform handshake when hooks, permissions, checkpointing, or SDK MCP servers configured
-	if t.needsProtocolHandshake() {
-		if _, err := t.protocol.Initialize(ctx); err != nil {
-			t.cleanup()
-			return fmt.Errorf("failed to initialize control protocol: %w", err)
-		}
-	}
-
 	return nil
+}
+
+// initializeControlProtocol waits for one terminal startup outcome instead of
+// folding process exit, stdout EOF, parser failures, and cancellation into the
+// protocol's generic timeout.
+func (t *Transport) initializeControlProtocol(ctx context.Context) error {
+	if t.closeStdin || !t.needsProtocolHandshake() {
+		return nil
+	}
+
+	initCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := t.protocol.Initialize(initCtx)
+		resultCh <- err
+	}()
+
+	waitForInit := func(err error) error {
+		cancel()
+		<-resultCh
+		return err
+	}
+
+	select {
+	case err := <-resultCh:
+		return err
+	case err := <-t.initFailure:
+		if ctx.Err() != nil {
+			return waitForInit(ctx.Err())
+		}
+		if errors.Is(err, errStdoutEOFDuringInit) {
+			select {
+			case <-t.processDone:
+				return waitForInit(t.processExitBeforeControlResponseError())
+			case <-time.After(processExitArbitrationDelay):
+			}
+		}
+		return waitForInit(err)
+	case <-t.processDone:
+		if ctx.Err() != nil {
+			return waitForInit(ctx.Err())
+		}
+		return waitForInit(t.processExitBeforeControlResponseError())
+	case <-ctx.Done():
+		return waitForInit(ctx.Err())
+	}
 }
 
 // needsProtocolHandshake returns true if control protocol handshake is required.
@@ -321,19 +374,12 @@ func (t *Transport) Close() error {
 
 	t.connected = false
 
-	// Close control protocol first (before cancelling context)
+	// Close the protocol and stdin first so a cooperative child can exit.
 	if t.protocol != nil {
 		_ = t.protocol.Close()
-		t.protocol = nil
 	}
 	if t.protocolAdapter != nil {
 		_ = t.protocolAdapter.Close()
-		t.protocolAdapter = nil
-	}
-
-	// Cancel context to stop goroutines
-	if t.cancel != nil {
-		t.cancel()
 	}
 
 	// Close stdin if open
@@ -342,26 +388,14 @@ func (t *Transport) Close() error {
 		t.stdin = nil
 	}
 
-	// Wait for goroutines to finish with timeout
-	done := make(chan struct{})
-	go func() {
-		t.wg.Wait()
-		close(done)
-	}()
+	// Terminate and reap before releasing process resources. cmd.Wait() has one
+	// owner: the waiter created immediately after cmd.Start().
+	err := t.terminateProcess()
 
-	select {
-	case <-done:
-		// Goroutines finished gracefully
-	case <-time.After(terminationTimeoutSeconds * time.Second):
-		// Timeout: proceed with cleanup anyway
-		// Goroutines should terminate when process is killed
+	if t.cancel != nil {
+		t.cancel()
 	}
-
-	// Terminate process with 5-second timeout
-	var err error
-	if t.cmd != nil && t.cmd.Process != nil {
-		err = t.terminateProcess()
-	}
+	t.wg.Wait()
 
 	// Cleanup resources
 	t.cleanup()


### PR DESCRIPTION
## Summary
- establish a single subprocess Wait owner immediately after Start
- surface process exit, stdout EOF, invalid JSONL, and mismatched control responses during initialize instead of waiting for generic timeout
- terminate and reap children on failed Connect paths, including context cancellation

## Verification
- `go test ./... -count=1`
- `go vet ./...`
- focused lifecycle regression in `internal/subprocess/lifecycle_fault_test.go`
