### PR TITLE
fix: Dispatch incoming control requests concurrently, parity with Python SDK (Issue #141)

### DIFF
--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -130,10 +130,15 @@ NewClient(opts...)
               │       ├─► parser.ProcessLine(line)
               │       ├─► Is control message?
               │       │       │
-              │       │       YES─► control.Protocol.HandleIncomingMessage()
+              │       │       YES─► control.Protocol.HandleIncomingMessageAsync()
               │       │       │         │
-              │       │       │         ├─► Match request ID
-              │       │       │         └─► Route to pending channel
+              │       │       │         ├─► control_response (inline)
+              │       │       │         │       ├─► Match request ID
+              │       │       │         │       └─► Route to pending channel
+              │       │       │         │
+              │       │       │         └─► control_request (own goroutine)
+              │       │       │                 ├─► Run hook / permission / MCP handler
+              │       │       │                 └─► Write control_response to stdin
               │       │       │
               │       │       NO──► Send to msgChan
               │       │
@@ -148,6 +153,12 @@ NewClient(opts...)
                       │
                       └─► Graceful shutdown sequence
 ```
+
+Incoming control requests are dispatched asynchronously: `HandleIncomingMessageAsync()`
+runs each `control_request` on its own goroutine so the reader never blocks on a user
+callback. A slow hook, permission check, or SDK MCP tool handler therefore cannot stall
+later messages on the same stream. Control responses and regular messages are still
+routed inline, in read order.
 
 ### WithClient Pattern
 
@@ -172,7 +183,9 @@ WithClient(ctx, fn, opts...)
 
 ## Control Protocol Flow
 
-Bidirectional communication for advanced features:
+Bidirectional communication for advanced features. Requests arriving from the CLI
+(permission checks, hooks, SDK MCP calls) each run on their own goroutine, so several
+can be in flight at once and the read loop keeps draining the stream while they work:
 
 ```
                         SDK                                   CLI

--- a/internal/control/CLAUDE.md
+++ b/internal/control/CLAUDE.md
@@ -28,7 +28,7 @@ control/
 **Protocol Flow**:
 1. `Initialize()`: Handshake with CLI, negotiate capabilities
 2. `SendControlRequest()`: Send JSON-RPC style requests with correlation IDs
-3. `HandleIncomingMessage()`: Route responses to pending requests
+3. `HandleIncomingMessage()`: Route responses to pending requests; read loops call `HandleIncomingMessageAsync()`, which dispatches incoming control requests on their own goroutine
 4. Hook/Permission callbacks: Invoked on tool use events (hooks.go, permissions.go)
 5. MCP messages: Route to SDK MCP servers (mcp.go)
 

--- a/internal/control/protocol.go
+++ b/internal/control/protocol.go
@@ -169,7 +169,7 @@ func (p *Protocol) readLoop() {
 			}
 
 			// Route the message
-			if err := p.HandleIncomingMessage(p.ctx, msg); err != nil {
+			if err := p.HandleIncomingMessageAsync(p.ctx, msg); err != nil {
 				fmt.Fprintf(os.Stderr, "claude-agent-sdk: failed to route control message: %v\n", err)
 				continue
 			}
@@ -262,6 +262,8 @@ func (p *Protocol) HandleControlInitErr(err error) {
 
 // HandleIncomingMessage routes incoming messages based on their type.
 // Control messages are handled internally, regular messages are forwarded to the stream.
+// Incoming control requests are handled synchronously; callers draining the CLI
+// stream should use HandleIncomingMessageAsync instead.
 func (p *Protocol) HandleIncomingMessage(ctx context.Context, msg map[string]any) error {
 	msgType, ok := msg["type"].(string)
 	if !ok {
@@ -279,6 +281,37 @@ func (p *Protocol) HandleIncomingMessage(ctx context.Context, msg map[string]any
 		// Regular SDK message - forward to stream
 		return p.forwardToStream(ctx, msg)
 	}
+}
+
+// HandleIncomingMessageAsync routes incoming messages like HandleIncomingMessage,
+// except that control requests from the CLI are dispatched on their own goroutine.
+// Read loops must use this so a slow user callback (MCP tool handler, hook, or
+// permission check) cannot stall processing of later messages on the same stream.
+func (p *Protocol) HandleIncomingMessageAsync(ctx context.Context, msg map[string]any) error {
+	if msgType, _ := msg["type"].(string); msgType != MessageTypeControlRequest {
+		return p.HandleIncomingMessage(ctx, msg)
+	}
+
+	// Deliberately not tracked by p.wg: Close must not block on a user callback
+	// that ignores ctx.
+	go func() {
+		requestID, _ := msg["request_id"].(string)
+		defer func() {
+			if r := recover(); r != nil {
+				fmt.Fprintf(os.Stderr, "claude-agent-sdk: control request handler panicked: %v\n", r)
+				// Best-effort: answer the CLI so its pending request does not hang forever.
+				if requestID != "" {
+					_ = p.sendErrorResponse(ctx, requestID, fmt.Sprintf("control request handler panicked: %v", r))
+				}
+			}
+		}()
+
+		if err := p.handleIncomingControlRequest(ctx, msg); err != nil {
+			fmt.Fprintf(os.Stderr, "claude-agent-sdk: failed to handle control request: %v\n", err)
+		}
+	}()
+
+	return nil
 }
 
 // handleIncomingControlRequest routes incoming control requests from CLI.

--- a/internal/control/protocol_test.go
+++ b/internal/control/protocol_test.go
@@ -13,6 +13,12 @@ import (
 
 const testModelSonnet = "claude-sonnet-4-5"
 
+const (
+	testBlockingServerName = "blocking"
+	testSlowToolName       = "slow"
+	testFastToolName       = "fast"
+)
+
 func TestControlMessageTypes(t *testing.T) {
 	t.Run("message_type_constants", testMessageTypeConstants)
 	t.Run("subtype_constants", testSubtypeConstants)
@@ -926,6 +932,101 @@ func testForwardToStreamFullBuffer(t *testing.T) {
 	}
 }
 
+// TestSlowControlRequestDoesNotBlockReadLoop verifies that a control request whose
+// handler blocks (here an SDK MCP tool call) does not stall the read loop: later
+// control requests are still answered and regular messages still reach the stream.
+func TestSlowControlRequestDoesNotBlockReadLoop(t *testing.T) {
+	ctx, cancel := setupControlTestContext(t, 10*time.Second)
+	defer cancel()
+
+	server := newBlockingMcpServer()
+	transport := newControlMockTransport()
+	protocol := NewProtocol(transport, WithSdkMcpServers(map[string]McpServer{testBlockingServerName: server}))
+
+	err := protocol.Start(ctx)
+	assertControlNoError(t, err)
+	defer func() { _ = protocol.Close() }()
+
+	// Wedge the first tool handler.
+	transport.injectMcpToolCall("req_slow", testBlockingServerName, testSlowToolName)
+	assertToolStarted(t, server, testSlowToolName)
+
+	// A second control request must still be picked up and answered.
+	transport.injectMcpToolCall("req_fast", testBlockingServerName, testFastToolName)
+	assertToolStarted(t, server, testFastToolName)
+
+	if !transport.waitForResponse("req_fast", time.Now().Add(5*time.Second)) {
+		t.Fatal("second control request was not answered while the first handler was blocked")
+	}
+
+	// Regular messages must keep flowing while the handler is blocked.
+	transport.readChan <- []byte(`{"type":"assistant","message":{"content":"hello"}}`)
+	select {
+	case received := <-protocol.ReceiveMessages():
+		assertControlEqual(t, "assistant", received["type"])
+	case <-time.After(5 * time.Second):
+		t.Fatal("regular message was not forwarded while a control request handler was blocked")
+	}
+
+	// The blocked handler answers once it is released.
+	close(server.release)
+	if !transport.waitForResponse("req_slow", time.Now().Add(5*time.Second)) {
+		t.Fatal("blocked control request was never answered")
+	}
+}
+
+// TestControlRequestPanicOutsideCallbackStillAnswersCLI verifies a panic during response marshaling (outside the inner callback recover) still answers the CLI with an error response.
+func TestControlRequestPanicOutsideCallbackStillAnswersCLI(t *testing.T) {
+	ctx, cancel := setupControlTestContext(t, 10*time.Second)
+	defer cancel()
+
+	transport := newControlMockTransport()
+
+	callback := func(_ context.Context, _ string, _ map[string]any, _ ToolPermissionContext) (PermissionResult, error) {
+		return PermissionResultAllow{
+			Behavior:     "allow",
+			UpdatedInput: map[string]any{"boom": panicMarshaler{}},
+		}, nil
+	}
+
+	protocol := NewProtocol(transport, WithCanUseToolCallback(callback))
+
+	err := protocol.Start(ctx)
+	assertControlNoError(t, err)
+	defer func() { _ = protocol.Close() }()
+
+	const requestID = "req_panic_outside"
+	request := map[string]any{
+		"type":       MessageTypeControlRequest,
+		"request_id": requestID,
+		"request": map[string]any{
+			"subtype":   SubtypeCanUseTool,
+			"tool_name": "Read",
+			"input":     map[string]any{},
+		},
+	}
+
+	// Async path is required: the outer recover only exists there.
+	err = protocol.HandleIncomingMessageAsync(ctx, request)
+	assertControlNoError(t, err)
+
+	data, ok := transport.waitForWrite(time.Now().Add(5*time.Second), func(data []byte) bool {
+		var resp SDKControlResponse
+		return json.Unmarshal(data, &resp) == nil && resp.Response.RequestID == requestID
+	})
+	if !ok {
+		t.Fatal("no control_response written after panic during response marshaling; CLI request would hang")
+		return
+	}
+	var resp SDKControlResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatalf("unmarshal control response: %v", err)
+		return
+	}
+	assertControlEqual(t, ResponseSubtypeError, resp.Response.Subtype)
+	assertControlEqual(t, requestID, resp.Response.RequestID)
+}
+
 func TestInterruptViaProtocol(t *testing.T) {
 	t.Run("sends_interrupt_request", testInterruptSendsRequest)
 }
@@ -1054,29 +1155,111 @@ func (m *controlMockTransport) injectErrorResponse(requestID string, errorMsg st
 	m.readChan <- data
 }
 
+// injectMcpToolCall pushes an incoming mcp_message control request onto the read
+// channel, as the CLI does when it calls a tool on an SDK MCP server.
+func (m *controlMockTransport) injectMcpToolCall(requestID, serverName, toolName string) {
+	req := map[string]any{
+		"type":       MessageTypeControlRequest,
+		"request_id": requestID,
+		"request": map[string]any{
+			"subtype":     SubtypeMcpMessage,
+			"server_name": serverName,
+			"message": map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"method":  "tools/call",
+				"params":  map[string]any{"name": toolName, "arguments": map[string]any{}},
+			},
+		},
+	}
+	data, _ := json.Marshal(req)
+	m.readChan <- data
+}
+
 func (m *controlMockTransport) getWriteCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.writtenData)
 }
 
-// waitForFirstWrite polls until the first write is available or the deadline passes.
-// Returns the parsed request and true on success, or the zero value and false on timeout.
-// Use this instead of time.Sleep + early-return to avoid flaky tests under load.
-func (m *controlMockTransport) waitForFirstWrite(deadline time.Time) (SDKControlRequest, bool) {
-	for time.Now().Before(deadline) {
+// waitForWrite polls until a written payload satisfies match or the deadline passes.
+func (m *controlMockTransport) waitForWrite(deadline time.Time, match func(data []byte) bool) ([]byte, bool) {
+	for {
 		m.mu.Lock()
-		if len(m.writtenData) > 0 {
-			var req SDKControlRequest
-			if err := json.Unmarshal(m.writtenData[0], &req); err == nil {
+		for _, data := range m.writtenData {
+			if match(data) {
 				m.mu.Unlock()
-				return req, true
+				return data, true
 			}
 		}
 		m.mu.Unlock()
+		if !time.Now().Before(deadline) {
+			return nil, false
+		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	return SDKControlRequest{}, false
+}
+
+// waitForFirstWrite polls until the first write is available or the deadline passes.
+func (m *controlMockTransport) waitForFirstWrite(deadline time.Time) (SDKControlRequest, bool) {
+	data, ok := m.waitForWrite(deadline, func([]byte) bool { return true })
+	if !ok {
+		return SDKControlRequest{}, false
+	}
+	var req SDKControlRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return SDKControlRequest{}, false
+	}
+	return req, true
+}
+
+// waitForResponse polls until a control response for requestID has been written or the deadline passes.
+func (m *controlMockTransport) waitForResponse(requestID string, deadline time.Time) bool {
+	_, ok := m.waitForWrite(deadline, func(data []byte) bool {
+		var resp SDKControlResponse
+		return json.Unmarshal(data, &resp) == nil && resp.Response.RequestID == requestID
+	})
+	return ok
+}
+
+// blockingMcpServer is an SDK MCP server whose slow tool blocks until released,
+// used to simulate a long-running tool handler.
+type blockingMcpServer struct {
+	started chan string
+	release chan struct{}
+}
+
+func newBlockingMcpServer() *blockingMcpServer {
+	return &blockingMcpServer{
+		started: make(chan string, 2),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *blockingMcpServer) Name() string {
+	return testBlockingServerName
+}
+
+func (s *blockingMcpServer) Version() string {
+	return "1.0.0"
+}
+
+func (s *blockingMcpServer) ListTools(_ context.Context) ([]McpToolDefinition, error) {
+	return []McpToolDefinition{{Name: testSlowToolName}, {Name: testFastToolName}}, nil
+}
+
+func (s *blockingMcpServer) CallTool(ctx context.Context, name string, _ map[string]any) (*McpToolResult, error) {
+	s.started <- name
+
+	if name == testSlowToolName {
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	return &McpToolResult{Content: []McpContent{{Type: "text", Text: name}}}, nil
 }
 
 func setupControlTestContext(t *testing.T, timeout time.Duration) (context.Context, context.CancelFunc) {
@@ -1096,6 +1279,23 @@ func assertControlEqual(t *testing.T, expected, actual any) {
 	if expected != actual {
 		t.Errorf("expected %v, got %v", expected, actual)
 	}
+}
+
+func assertToolStarted(t *testing.T, server *blockingMcpServer, toolName string) {
+	t.Helper()
+	select {
+	case started := <-server.started:
+		assertControlEqual(t, toolName, started)
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout waiting for tool %q handler to start", toolName)
+	}
+}
+
+// panicMarshaler is a json.Marshaler whose MarshalJSON panics, to force a marshal-time panic.
+type panicMarshaler struct{}
+
+func (panicMarshaler) MarshalJSON() ([]byte, error) {
+	panic("boom during response marshaling")
 }
 
 func TestDynamicControlMethods(t *testing.T) {

--- a/internal/subprocess/CLAUDE.md
+++ b/internal/subprocess/CLAUDE.md
@@ -28,7 +28,7 @@ subprocess/
 1. `Connect()`: Spawn CLI subprocess with configured arguments
 2. `SendMessage()`: Write JSON messages to stdin
 3. `handleStdout()`: Read stdout, parse JSON, route messages (io.go)
-4. Control messages: Route to `control.Protocol.HandleIncomingMessage()`
+4. Control messages: Route to `control.Protocol.HandleIncomingMessageAsync()` (incoming control requests run on their own goroutine so a slow callback cannot stall `handleStdout()`)
 5. `Close()`: SIGTERM -> wait 5s -> SIGKILL (process.go)
 
 <!-- END AUTO-MANAGED -->

--- a/internal/subprocess/io.go
+++ b/internal/subprocess/io.go
@@ -67,9 +67,11 @@ func (t *Transport) handleStdout() {
 			if rawCtrl, ok := msg.(*shared.RawControlMessage); ok {
 				// Route control messages to the protocol for request/response correlation
 				if t.protocol != nil {
-					// HandleIncomingMessage routes control responses to pending requests
-					// and forwards non-control messages to the protocol's message stream
-					_ = t.protocol.HandleIncomingMessage(t.ctx, rawCtrl.Data)
+					// HandleIncomingMessageAsync routes control responses to pending
+					// requests, dispatches incoming control requests on their own
+					// goroutine so a slow callback cannot stall this reader, and
+					// forwards non-control messages to the protocol's message stream
+					_ = t.protocol.HandleIncomingMessageAsync(t.ctx, rawCtrl.Data)
 				}
 				// Don't send control messages to msgChan - they're internal to the protocol
 				continue

--- a/internal/subprocess/protocol_adapter.go
+++ b/internal/subprocess/protocol_adapter.go
@@ -12,7 +12,7 @@ import (
 //
 // Note: The Read() method returns a closed channel because we don't use the
 // protocol's built-in readLoop. Instead, subprocess.Transport routes control
-// messages directly to protocol.HandleIncomingMessage() from handleStdout().
+// messages to protocol.HandleIncomingMessageAsync() from handleStdout().
 type ProtocolAdapter struct {
 	stdin    io.Writer
 	mu       sync.Mutex
@@ -58,8 +58,8 @@ func (pa *ProtocolAdapter) Write(ctx context.Context, data []byte) error {
 
 // Read returns a channel for reading data from the subprocess.
 // This channel is pre-closed because we don't use the protocol's built-in
-// readLoop - instead, subprocess.Transport routes control messages directly
-// to protocol.HandleIncomingMessage() from handleStdout().
+// readLoop - instead, subprocess.Transport routes control messages to
+// protocol.HandleIncomingMessageAsync() from handleStdout().
 func (pa *ProtocolAdapter) Read(_ context.Context) <-chan []byte {
 	return pa.readChan
 }


### PR DESCRIPTION
## Summary
- Dispatch each incoming control request on its own goroutine (`HandleIncomingMessageAsync`, used by both `readLoop` and `handleStdout`) so a slow hook/permission/MCP-tool callback no longer stalls the read loop — and the responses that would unblock it.
- The dispatch goroutine now answers the CLI with an error `control_response` when a handler panics outside the per-callback recovers, instead of only logging (previously the request hung forever).
- Tests for the blocked-handler and panic cases, plus test-helper cleanup (inline single-use constants, shared `waitForWrite`).
- Closes #141 